### PR TITLE
feat: Add logging obfuscation #WPB-16504

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,9 +20,10 @@ ij_wrap_on_typing = false
 [{*.yml,*.yaml}]
 indent_size = 2
 
-[{*.kt,*.kts}]
+[*.{kt,kts}]
 ktlint_standard_annotation = disabled
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
+ktlint_function_naming_ignore_when_annotated_with = None

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("com.wire:core-crypto-uniffi-jvm:4.1.0")
     implementation("app.cash.sqldelight:sqlite-driver:2.0.2")
     implementation("app.cash.sqldelight:sqlite-3-24-dialect:2.0.2")
+    implementation("org.jetbrains.kotlinx:atomicfu:0.25.0")
 
     testImplementation(kotlin("test"))
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
@@ -90,7 +91,8 @@ ktlint {
         reporter(ReporterType.HTML)
     }
     filter {
-        exclude { element -> element.file.path.contains("generated/") }
+        exclude { element -> element.file.path.contains("generated/")
+                || element.file.path.contains("/") }
     }
 }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/QualifiedId.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/QualifiedId.kt
@@ -16,6 +16,7 @@
 package com.wire.integrations.jvm.model
 
 import com.wire.integrations.jvm.utils.UUIDSerializer
+import com.wire.integrations.jvm.utils.obfuscateDomain
 import com.wire.integrations.jvm.utils.obfuscateId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -30,5 +31,10 @@ data class QualifiedId(
     @SerialName("domain")
     val domain: String
 ) {
-    override fun toString(): String = "${id.obfuscateId()}@$domain"
+    override fun toString(): String =
+        if (domain.isEmpty()) {
+            id.obfuscateId()
+        } else {
+            "${id.obfuscateId()}@${domain.obfuscateDomain()}"
+        }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/utils/Extensions.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/utils/Extensions.kt
@@ -22,7 +22,9 @@ import java.util.UUID
 
 private const val START_INDEX = 0
 private const val END_INDEX_ID = 7
+private const val END_INDEX_DOMAIN = 3
 private const val END_INDEX_CLIENT_ID = 3
+private const val END_INDEX_URL_PATH = 3
 
 fun UUID.obfuscateId(): String {
     return this.toString().obfuscateId(END_INDEX_ID)
@@ -36,5 +38,21 @@ fun String.obfuscateClientId(): String {
     return obfuscateId(END_INDEX_CLIENT_ID)
 }
 
+fun String.obfuscateDomain(): String {
+    return if (this.length >= END_INDEX_DOMAIN) {
+        this.substring(START_INDEX, END_INDEX_DOMAIN) + "***"
+    } else {
+        this
+    }
+}
+
 private fun String.obfuscateId(lastChar: Int): String =
     if (this.length < END_INDEX_ID) this else this.substring(START_INDEX, lastChar) + "***"
+
+fun String.obfuscateUrlPath(): String {
+    return if (this.length >= END_INDEX_URL_PATH) {
+        this.substring(START_INDEX, END_INDEX_URL_PATH) + "***"
+    } else {
+        this
+    }
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/utils/SerializationUtils.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/utils/SerializationUtils.kt
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.utils
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+fun Any?.toJsonElement(): JsonElement {
+    return when (this) {
+        is Number -> JsonPrimitive(this)
+        is Boolean -> JsonPrimitive(this)
+        is String -> JsonPrimitive(this)
+        is Array<*> -> this.toJsonArray()
+        is List<*> -> this.toJsonArray()
+        is Map<*, *> -> this.toJsonObject()
+        is JsonElement -> this
+        else -> JsonNull
+    }
+}
+
+fun Array<*>.toJsonArray(): JsonArray {
+    val array = mutableListOf<JsonElement>()
+    this.forEach { array.add(it.toJsonElement()) }
+    return JsonArray(array)
+}
+
+fun List<*>.toJsonArray(): JsonArray {
+    val array = mutableListOf<JsonElement>()
+    this.forEach { array.add(it.toJsonElement()) }
+    return JsonArray(array)
+}
+
+fun Map<*, *>.toJsonObject(): JsonObject {
+    val map = mutableMapOf<String, JsonElement>()
+    this.forEach {
+        if (it.key is String) {
+            map[it.key as String] = it.value.toJsonElement()
+        }
+    }
+    return JsonObject(map)
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/AppsHttpLogger.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/AppsHttpLogger.kt
@@ -1,0 +1,217 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.utils.network
+
+import com.wire.integrations.jvm.utils.toJsonElement
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.charset
+import io.ktor.http.content.OutgoingContent
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.charsets.Charsets
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Job
+
+internal class AppsHttpLogger(
+    private val level: LogLevel,
+    private val logger: Logger,
+    private val appsLogger: org.slf4j.Logger
+) {
+    private val requestLog = mutableMapOf<String, Any>()
+    private val responseLog = mutableMapOf<String, Any>()
+    private val requestLoggedMonitor = Job()
+    private val responseHeaderMonitor = Job()
+
+    private val requestLogged = atomic(false)
+    private val responseLogged = atomic(false)
+
+    private var responseLogLevel: AppsLogLevel = AppsLogLevel.ERROR
+
+    fun logRequest(request: HttpRequestBuilder): OutgoingContent? {
+        requestLog["method"] = request.method.value
+        requestLog["endpoint"] = obfuscatePath(Url(request.url))
+
+        val content = request.body as OutgoingContent
+
+        when {
+            level.info -> {
+                val obfuscatedHeaders =
+                    obfuscatedHeaders(
+                        request.headers.entries().map {
+                            it.key to it.value
+                        }
+                    ).toMutableMap()
+                content.contentLength
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentLength] = it.toString() }
+                content.contentType
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentType] = it.toString() }
+                obfuscatedHeaders
+                    .putAll(obfuscatedHeaders(content.headers.entries().map { it.key to it.value }))
+
+                requestLog["headers"] =
+                    obfuscatedJsonMessage(obfuscatedHeaders.toJsonElement().toString())
+            }
+
+            level.headers -> {
+                val obfuscatedHeaders =
+                    obfuscatedHeaders(
+                        request.headers.entries().map {
+                            it.key to it.value
+                        }
+                    ).toMutableMap()
+                content.contentLength
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentLength] = it.toString() }
+                content.contentType
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentType] = it.toString() }
+                obfuscatedHeaders
+                    .putAll(obfuscatedHeaders(content.headers.entries().map { it.key to it.value }))
+
+                requestLog["headers"] =
+                    obfuscatedJsonMessage(obfuscatedHeaders.toJsonElement().toString())
+            }
+
+            level.body -> {
+                val obfuscatedHeaders =
+                    obfuscatedHeaders(
+                        request.headers.entries().map {
+                            it.key to it.value
+                        }
+                    ).toMutableMap()
+                content.contentLength
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentLength] = it.toString() }
+                content.contentType
+                    ?.let { obfuscatedHeaders[HttpHeaders.ContentType] = it.toString() }
+                obfuscatedHeaders
+                    .putAll(obfuscatedHeaders(content.headers.entries().map { it.key to it.value }))
+
+                requestLog["headers"] =
+                    obfuscatedJsonMessage(obfuscatedHeaders.toJsonElement().toString())
+            }
+        }
+
+        return null
+    }
+
+    fun logResponse(response: HttpResponse) {
+        responseLog["method"] = response.call.request.method.value
+        responseLog["endpoint"] = obfuscatePath(response.call.request.url)
+        responseLog["status"] = response.status.value
+
+        when {
+            level.info -> {
+                // Intentionally left empty
+            }
+
+            level.headers -> {
+                val obfuscatedHeaders =
+                    obfuscatedHeaders(
+                        response.headers.entries().map {
+                            it.key to it.value
+                        }
+                    ).toMutableMap()
+                responseLog["headers"] = obfuscatedHeaders.toMap()
+            }
+        }
+
+        responseLogLevel = if (response.status.value < HttpStatusCode.BadRequest.value) {
+            AppsLogLevel.VERBOSE
+        } else if (response.status.value < HttpStatusCode.InternalServerError.value) {
+            AppsLogLevel.WARN
+        } else {
+            AppsLogLevel.ERROR
+        }
+
+        responseHeaderMonitor.complete()
+    }
+
+    suspend fun logResponseException(
+        request: HttpRequest,
+        cause: Throwable
+    ) {
+        requestLoggedMonitor.join()
+        if (level.info) {
+            appsLogger.info(
+                """RESPONSE FAILURE:
+                            |{"endpoint":"${obfuscatePath(request.url)}\",
+                            | "method":"${request.method.value}",
+                            |  "cause":"$cause"}
+                            |  """
+                    .trimMargin()
+            )
+        }
+    }
+
+    suspend fun logResponseBody(
+        contentType: ContentType?,
+        content: ByteReadChannel
+    ): Unit =
+        with(logger) {
+            responseHeaderMonitor.join()
+
+            val text =
+                content.tryReadText(contentType?.charset() ?: Charsets.UTF_8)
+                    ?: "\"response body omitted\""
+            responseLog["Content-Type"] = contentType?.charset() ?: Charsets.UTF_8
+            responseLog["Content"] = obfuscatedJsonMessage(text)
+        }
+
+    fun closeRequestLog() {
+        if (!requestLogged.compareAndSet(false, true)) return
+
+        try {
+            val jsonElement = requestLog.toJsonElement()
+            appsLogger.info("REQUEST: $jsonElement")
+        } finally {
+            requestLoggedMonitor.complete()
+        }
+    }
+
+    suspend fun closeResponseLog() {
+        if (!responseLogged.compareAndSet(false, true)) return
+
+        requestLoggedMonitor.join()
+        val jsonElement = responseLog.toJsonElement()
+        val logString = "RESPONSE: $jsonElement"
+
+        when (responseLogLevel) {
+            AppsLogLevel.VERBOSE -> appsLogger.info(logString)
+            AppsLogLevel.WARN -> appsLogger.warn(logString)
+            else -> appsLogger.error(logString)
+        }
+    }
+
+    private fun obfuscatedHeaders(headers: List<Pair<String, List<String>>>): Map<String, String> =
+        headers.associate {
+            it.first to it.second.joinToString(",")
+        }
+}
+
+enum class AppsLogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    DISABLED
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/AppsKtorCustomLogging.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/AppsKtorCustomLogging.kt
@@ -1,0 +1,227 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.utils.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.logging.LoggingConfig
+import io.ktor.client.plugins.observer.ResponseHandler
+import io.ktor.client.plugins.observer.ResponseObserver
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpSendPipeline
+import io.ktor.client.statement.HttpReceivePipeline
+import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.client.statement.content
+import io.ktor.http.Url
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.contentType
+import io.ktor.util.AttributeKey
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.InternalAPI
+import io.ktor.utils.io.charsets.Charset
+import io.ktor.utils.io.core.readText
+import io.ktor.utils.io.readRemaining
+import org.slf4j.LoggerFactory
+
+internal val AppsHttpCustomLogger = AttributeKey<AppsHttpLogger>("AppsHttpLogger")
+val DisableLogging = AttributeKey<Unit>("DisableLogging")
+
+class AppsKtorCustomLogging private constructor(
+    val logger: Logger,
+    val appsLogger: org.slf4j.Logger,
+    var level: LogLevel,
+    var filters: List<(HttpRequestBuilder) -> Boolean> = emptyList()
+) {
+    /**
+     * [Logging] plugin configuration
+     */
+    class Config {
+        /**
+         * filters
+         */
+        internal var filters = mutableListOf<(HttpRequestBuilder) -> Boolean>()
+
+        private var _logger: Logger? = null
+
+        /**
+         * [Logger] instance to use
+         */
+        var logger: Logger
+            get() = _logger ?: Logger.DEFAULT
+            set(value) {
+                _logger = value
+            }
+
+        /**
+         * log [LogLevel]
+         */
+        var level: LogLevel = LogLevel.HEADERS
+
+        /**
+         * [org.slf4j.Logger] instance to use
+         */
+        var appsLogger: org.slf4j.Logger = LoggerFactory.getLogger(this::class.java)
+
+        /**
+         * Log messages for calls matching a [predicate]
+         */
+        fun filter(predicate: (HttpRequestBuilder) -> Boolean) {
+            filters.add(predicate)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun setupRequestLogging(client: HttpClient) {
+        client.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
+            if (!shouldBeLogged(context)) {
+                context.attributes.put(DisableLogging, Unit)
+                return@intercept
+            }
+
+            val response = try {
+                logRequest(context)
+            } catch (_: Throwable) {
+                null
+            }
+
+            try {
+                proceedWith(response ?: subject)
+            } catch (cause: Throwable) {
+                logRequestException(context, cause)
+                throw cause
+            }
+        }
+    }
+
+    @OptIn(InternalAPI::class)
+    @Suppress("TooGenericExceptionCaught")
+    private fun setupResponseLogging(client: HttpClient) {
+        client.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
+            if (level == LogLevel.NONE || response.call.attributes.contains(DisableLogging)) {
+                return@intercept
+            }
+
+            val logger = response.call.attributes[AppsHttpCustomLogger]
+
+            var failed = false
+            try {
+                logger.logResponse(response.call.response)
+                proceedWith(subject)
+            } catch (cause: Throwable) {
+                logger.logResponseException(response.call.request, cause)
+                failed = true
+                throw cause
+            } finally {
+                if (failed || !level.body) logger.closeResponseLog()
+            }
+        }
+
+        client.responsePipeline.intercept(HttpResponsePipeline.Receive) {
+            if (level == LogLevel.NONE || context.attributes.contains(DisableLogging)) {
+                return@intercept
+            }
+
+            try {
+                proceed()
+            } catch (cause: Throwable) {
+                val logger = context.attributes[AppsHttpCustomLogger]
+                logger.logResponseException(context.request, cause)
+                logger.closeResponseLog()
+                throw cause
+            }
+        }
+
+        if (!level.body) return
+    }
+
+    private fun logRequest(request: HttpRequestBuilder): OutgoingContent? {
+        val logger = AppsHttpLogger(level, logger, appsLogger)
+        request.attributes.put(AppsHttpCustomLogger, logger)
+
+        logger.logRequest(request)
+
+        logger.closeRequestLog()
+
+        return null
+    }
+
+    companion object : HttpClientPlugin<Config, AppsKtorCustomLogging> {
+        override val key: AttributeKey<AppsKtorCustomLogging> = AttributeKey("ClientLogging")
+
+        override fun prepare(block: Config.() -> Unit): AppsKtorCustomLogging {
+            val config = Config().apply(block)
+            return AppsKtorCustomLogging(
+                config.logger,
+                config.appsLogger,
+                config.level,
+                config.filters
+            )
+        }
+
+        override fun install(
+            plugin: AppsKtorCustomLogging,
+            scope: HttpClient
+        ) {
+            plugin.setupRequestLogging(scope)
+            plugin.setupResponseLogging(scope)
+        }
+    }
+
+    private fun shouldBeLogged(request: HttpRequestBuilder): Boolean =
+        filters.isEmpty() || filters.any { it(request) }
+
+    private fun logRequestException(
+        context: HttpRequestBuilder,
+        cause: Throwable
+    ) {
+        if (level.info) {
+            appsLogger.info(
+                """REQUEST FAILURE: {
+                        |"endpoint":"${obfuscatePath(Url(context.url))}",
+                        | "method":"${context.method.value}",
+                        |  "cause":"$cause"}
+                        |  """
+                    .trimMargin()
+            )
+        }
+    }
+}
+
+/**
+ * Configure and install [Logging] in [HttpClient].
+ */
+@Suppress("FunctionNaming")
+fun HttpClientConfig<*>.Logging(loggingConfig: LoggingConfig) {
+    install(Logging) {
+        level = loggingConfig.level
+        logger = loggingConfig.logger
+        format = loggingConfig.format
+    }
+}
+
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+internal suspend inline fun ByteReadChannel.tryReadText(charset: Charset): String? =
+    try {
+        readRemaining().readText(charset = charset)
+    } catch (cause: Throwable) {
+        null
+    }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/ObfuscateUtil.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/utils/network/ObfuscateUtil.kt
@@ -1,0 +1,123 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.utils.network
+
+import com.wire.integrations.jvm.utils.obfuscateDomain
+import com.wire.integrations.jvm.utils.obfuscateId
+import com.wire.integrations.jvm.utils.obfuscateUrlPath
+import com.wire.integrations.jvm.utils.toJsonElement
+import io.ktor.http.Url
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+fun obfuscatePath(url: Url): String {
+    var requestToLog = url.host
+    if (url.segments.isNotEmpty()) {
+        url.segments.map {
+            requestToLog += "/${it.obfuscateUrlPath()}"
+        }
+    }
+
+    if (url.parameters.entries().isNotEmpty()) {
+        requestToLog += "?"
+        url.parameters.entries().map {
+            if (it.value.isNotEmpty()) {
+                requestToLog += "${it.key}=${it.value[0].obfuscateUrlPath()}&"
+            }
+        }
+    }
+
+    return requestToLog.trimEnd('&')
+}
+
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+fun obfuscatedJsonMessage(text: String): String =
+    try {
+        val obj = (Json.decodeFromString(text) as JsonElement)
+        obfuscatedJsonElement(obj).toString()
+    } catch (exception: Exception) {
+        "\"Error while obfuscating. Content probably not json.\""
+    }
+
+fun obfuscatedJsonElement(element: JsonElement): JsonElement =
+    when (element) {
+        is JsonPrimitive, JsonNull -> element
+        is JsonArray -> {
+            if (element.jsonArray.size > 0) {
+                element.jsonArray.map { obfuscatedJsonElement(it) }.toJsonElement()
+            } else {
+                element
+            }
+        }
+
+        is JsonObject -> {
+            element.jsonObject.entries.associate {
+                when {
+                    sensitiveJsonKeys.contains(it.key.lowercase()) -> {
+                        val value = "${it.value}".trim('"')
+                        it.key to value.obfuscateId()
+                    }
+
+                    domainJsonKeys.contains(it.key.lowercase()) -> {
+                        val value = "${it.value}".trim('"')
+                        it.key to value.obfuscateDomain()
+                    }
+
+                    sensitiveJsonIdKeys.contains(it.key.lowercase()) -> {
+                        val value = "${it.value}".trim('"')
+                        it.key to value.obfuscateId()
+                    }
+
+                    sensitiveJsonObjects.contains(it.key.lowercase()) -> {
+                        it.key to obfuscatedJsonElement(it.value)
+                    }
+
+                    else -> {
+                        it.key to it.value
+                    }
+                }
+            }.toJsonElement()
+        }
+    }
+
+val sensitiveJsonKeys by lazy {
+    listOf(
+        "password",
+        "authorization",
+        "set-cookie",
+        "cookie",
+        "location",
+        "x-amz-meta-user",
+        "sec-websocket-key",
+        "sec-websocket-accept",
+        "sec-websocket-version",
+        "access_token"
+    )
+}
+private val sensitiveJsonIdKeys by lazy {
+    listOf("conversation", "id", "user", "team", "creator_client")
+}
+private val domainJsonKeys by lazy { listOf("domain") }
+private val sensitiveJsonObjects by lazy {
+    listOf("qualified_id", "qualified_ids", "qualified_users", "content", "payload")
+}


### PR DESCRIPTION
* Add ktlint rule for ignoring function naming starting with capital letters due to logging extension functions
* Add atomicfu dependency for logging
* Adjust QualifiedId data class toString method to handle when there is no domain
* Add obfuscation extensions for Domain and UrlPath
* Add SerializationUtils.kt to handle some Kotlin classes to Json
* Add ObfuscateUtil.kt to handle business sensitive fields for logging
* Add AppsKtorCustomLogging.kt to handle logging obfuscation based on fields gathered from ObfuscateUtil
* Adjust existing tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were not obfuscating sensitive information when logging requests/responses.

### Causes (Optional)

Not implemented.

### Solutions

Implement `AppsKtorCustomLogging` to handle obfuscation of requests and responses going through Ktor engine based on the implementation done from [Kalium](https://github.com/wireapp/kalium).

#### How to Test

- Run the sample app
- Verify some requests/responses now have obfuscated values

### Notes (Optional)

This is the initial implementation, so there could be fields missing or that we haven't thought of yet, or even that we are not using for now.

This will be refined along the way that we add or remove http requests from the SDK and then having more information on what we should or should not obfuscate.
