### PR TITLE
feat: Add logging obfuscation #WPB-16504

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,9 +20,10 @@ ij_wrap_on_typing = false
 [{*.yml,*.yaml}]
 indent_size = 2
 
-[{*.kt,*.kts}]
+[*.{kt,kts}]
 ktlint_standard_annotation = disabled
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
+ktlint_standard_import-ordering = disabled

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
     implementation("com.wire:core-crypto-uniffi-jvm:4.1.0")
     implementation("app.cash.sqldelight:sqlite-driver:2.0.2")
     implementation("app.cash.sqldelight:sqlite-3-24-dialect:2.0.2")
+    implementation("org.zalando:logbook-core:3.11.0")
+    implementation("org.zalando:logbook-ktor-client:3.11.0")
+    implementation("org.zalando:logbook-json:3.11.0")
 
     testImplementation(kotlin("test"))
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/logging/LoggingConfiguration.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/logging/LoggingConfiguration.kt
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.logging
+
+import org.zalando.logbook.Logbook
+import org.zalando.logbook.core.DefaultHttpLogWriter
+import org.zalando.logbook.core.DefaultSink
+import org.zalando.logbook.core.HeaderFilters
+import org.zalando.logbook.core.QueryFilters
+import org.zalando.logbook.json.JsonBodyFilters
+import org.zalando.logbook.json.JsonHttpLogFormatter
+
+internal object LoggingConfiguration {
+    private const val OBFUSCATION_VALUE = "****"
+
+    private val sensitiveHeaderParams = setOf(
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "location",
+        "x-amz-meta-user",
+        "sec-websocket-key",
+        "sec-websocket-accept",
+        "sec-websocket-version"
+    )
+
+    private val sensitiveQueryParams = setOf(
+        "password",
+        "access_token",
+        "conversation",
+        "id",
+        "user",
+        "team"
+    )
+
+    private val sensitiveBodyParams = setOf(
+        "id",
+        "user",
+        "team",
+        "access_token",
+        "creator_client",
+        "qualified_id",
+        "qualified_ids",
+        "qualified_users",
+        "content",
+        "payload"
+    )
+
+    val logbook: Logbook = Logbook.builder()
+        .condition { true }
+        .headerFilter(
+            HeaderFilters.replaceHeaders(
+                sensitiveHeaderParams,
+                OBFUSCATION_VALUE
+            )
+        )
+        .queryFilter(
+            QueryFilters.replaceQuery({ key -> key in sensitiveQueryParams }, OBFUSCATION_VALUE)
+        )
+        .bodyFilter(
+            JsonBodyFilters.replaceJsonStringProperty(
+                sensitiveBodyParams,
+                OBFUSCATION_VALUE
+            )
+        )
+        .sink(
+            DefaultSink(
+                JsonHttpLogFormatter(),
+                DefaultHttpLogWriter()
+            )
+        )
+        .build()
+}

--- a/lib/src/main/resources/logback.xml
+++ b/lib/src/main/resources/logback.xml
@@ -4,8 +4,10 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 
-    <root level="info">
+    <root level="info" additivity="false">
         <appender-ref ref="STDOUT"/>
     </root>
+
+    <logger name="org.zalando.logbook" level="TRACE" />
 
 </configuration>


### PR DESCRIPTION
* Add ktlint rule for ignoring standard import ordering
* Add Logbook dependency
* Add Logbook dependency to Logback.xml
* Creation of package and object of LoggingConfiguration to hold what we have now (Logbook).

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no obfuscation on logs for HTTP requests/responses.

### Causes (Optional)

Not implemented.

### Solutions

Added [Logbook](https://github.com/zalando/logbook/) library to handle the obfuscation of HTTP requests/responses and informations on headers.

The configuration can be checked in `LoggingConfiguration.kt` which also holds the sensitive keys we are obfuscating (which those are prone to changes in the future, in case we either need or don't need some keys anymore).

.Also to compare against https://github.com/wireapp/wire-apps-jvm-sdk/pull/39
