### PR TITLE
feat: Add common coroutine scope in the SDK #WPB-15821

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,16 +2,16 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-      <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient$3</ID>
-      <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient$4</ID>
-      <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient$5</ID>
-      <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient$6</ID>
-      <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient$7</ID>
+    <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$3</ID>
+    <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$4</ID>
+    <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$5</ID>
+    <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$6</ID>
+    <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$7</ID>
     <ID>TooGenericExceptionCaught:WireExceptionMapper.kt$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:WireTeamEventsListener.kt$WireTeamEventsListener$e: Exception</ID>
-      <ID>TooManyFunctions:BackendClient.kt$BackendClient</ID>
+    <ID>TooManyFunctions:BackendClient.kt$BackendClient</ID>
     <ID>TooManyFunctions:BackendClientDemo.kt$BackendClientDemo : BackendClient</ID>
-      <ID>TooManyFunctions:BackendClientImpl.kt$BackendClientImpl : BackendClient</ID>
-      <ID>TooManyFunctions:CoreCryptoClient.kt$CoreCryptoClient : CryptoClient</ID>
+    <ID>TooManyFunctions:BackendClientImpl.kt$BackendClientImpl : BackendClient</ID>
+    <ID>TooManyFunctions:CoreCryptoClient.kt$CoreCryptoClient : CryptoClient</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
@@ -33,7 +33,7 @@ abstract class WireEventsHandler {
     }
 
     open fun onNewMLSMessage(value: String) {
-        logger.info("Received event: onNewMLSMessage")
+        logger.info("Received event: onNewMLSMessage - message content: $value")
     }
 
     open fun onMemberJoin(value: String) {

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -30,29 +30,29 @@ import kotlinx.coroutines.channels.ReceiveChannel
 interface BackendClient {
     suspend fun connectWebSocket(handleFrames: suspend (ReceiveChannel<Frame>) -> Unit)
 
-    fun getBackendVersion(): ApiVersionResponse
+    suspend fun getBackendVersion(): ApiVersionResponse
 
-    fun getApplicationData(): AppDataResponse
+    suspend fun getApplicationData(): AppDataResponse
 
-    fun getApplicationFeatures(): FeaturesResponse
+    suspend fun getApplicationFeatures(): FeaturesResponse
 
-    fun confirmTeam(teamId: TeamId)
+    suspend fun confirmTeam(teamId: TeamId)
 
-    fun updateClientWithMlsPublicKey(
+    suspend fun updateClientWithMlsPublicKey(
         appClientId: AppClientId,
         mlsPublicKeys: MlsPublicKeys
     )
 
-    fun uploadMlsKeyPackages(
+    suspend fun uploadMlsKeyPackages(
         appClientId: AppClientId,
         mlsKeyPackages: List<ByteArray>
     )
 
-    fun uploadCommitBundle(commitBundle: ByteArray)
+    suspend fun uploadCommitBundle(commitBundle: ByteArray)
 
-    fun sendMessage(mlsMessage: ByteArray)
+    suspend fun sendMessage(mlsMessage: ByteArray)
 
-    fun getConversation(conversationId: QualifiedId): ConversationResponse
+    suspend fun getConversation(conversationId: QualifiedId): ConversationResponse
 
-    fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray
+    suspend fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
@@ -35,7 +35,6 @@ import io.ktor.client.request.post
 import io.ktor.http.HttpHeaders
 import io.ktor.websocket.Frame
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 
 /**
@@ -59,65 +58,61 @@ internal class BackendClientImpl internal constructor(
         }
     }
 
-    override fun getBackendVersion(): ApiVersionResponse {
+    override suspend fun getBackendVersion(): ApiVersionResponse {
         logger.info("Fetching Wire backend version")
         return runWithWireException {
-            runBlocking { httpClient.get("/$API_VERSION/api-version").body() }
+            httpClient.get("/$API_VERSION/api-version").body()
         }
     }
 
-    override fun getApplicationData(): AppDataResponse {
+    override suspend fun getApplicationData(): AppDataResponse {
         logger.info("Fetching application data")
         return runWithWireException {
-            runBlocking { httpClient.get("/$API_VERSION/apps").body() }
+            httpClient.get("/$API_VERSION/apps").body()
         }
     }
 
-    override fun getApplicationFeatures(): FeaturesResponse {
+    override suspend fun getApplicationFeatures(): FeaturesResponse {
         logger.info("Fetching application enabled features")
         return runWithWireException {
-            runBlocking {
-                httpClient.get("/$API_VERSION/apps/feature-configs").body()
-            }
+            httpClient.get("/$API_VERSION/apps/feature-configs").body()
         }
     }
 
-    override fun confirmTeam(teamId: TeamId) {
+    override suspend fun confirmTeam(teamId: TeamId) {
         logger.info("Confirming team invite")
         runWithWireException {
-            runBlocking {
-                httpClient.post("/$API_VERSION/apps/teams/${teamId.value}/confirm")
-            }
+            httpClient.post("/$API_VERSION/apps/teams/${teamId.value}/confirm")
         }
     }
 
-    override fun updateClientWithMlsPublicKey(
+    override suspend fun updateClientWithMlsPublicKey(
         appClientId: AppClientId,
         mlsPublicKeys: MlsPublicKeys
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun uploadMlsKeyPackages(
+    override suspend fun uploadMlsKeyPackages(
         appClientId: AppClientId,
         mlsKeyPackages: List<ByteArray>
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun uploadCommitBundle(commitBundle: ByteArray) {
+    override suspend fun uploadCommitBundle(commitBundle: ByteArray) {
         TODO("Not yet implemented")
     }
 
-    override fun sendMessage(mlsMessage: ByteArray) {
+    override suspend fun sendMessage(mlsMessage: ByteArray) {
         TODO("Not yet implemented")
     }
 
-    override fun getConversation(conversationId: QualifiedId): ConversationResponse {
+    override suspend fun getConversation(conversationId: QualifiedId): ConversationResponse {
         TODO("Not yet implemented")
     }
 
-    override fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray {
+    override suspend fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray {
         TODO("Not yet implemented")
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
@@ -36,7 +36,7 @@ internal object IsolatedKoinContext {
         this.koinApp.koin.setProperty(API_HOST, value)
     }
 
-    fun getApiHost() = this.koinApp.koin.getProperty<String>(API_HOST)
+    fun getApiHost(): String? = this.koinApp.koin.getProperty<String>(API_HOST)
 
     fun setApiToken(value: String) {
         this.koinApp.koin.setProperty(API_TOKEN, value)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -26,66 +26,100 @@ internal class CoreCryptoClient : CryptoClient {
     private val ciphersuite: Ciphersuite
     private var coreCrypto: CoreCrypto
 
-    constructor(
+    /**
+     * Internal use only, use the factory function [create] to create a new instance.
+     */
+    private constructor(
         appClientId: AppClientId,
-        ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER,
-        mlsTransport: MlsTransport
+        ciphersuite: Ciphersuite,
+        coreCrypto: CoreCrypto
     ) {
         this.appClientId = appClientId
-        this.ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
-        val clientDirectoryPath = "cryptography/${appClientId.value}"
-        val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
+        this.ciphersuite = ciphersuite
+        this.coreCrypto = coreCrypto
+    }
 
-        File(clientDirectoryPath).mkdirs()
-        runBlocking {
-            coreCrypto = CoreCrypto.invoke(
+    companion object {
+        private const val DEFAULT_CIPHERSUITE_IDENTIFIER = 1
+        private const val KEYSTORE_NAME = "keystore"
+
+        /**
+         * Creates a CoreCryptoClient instance in a coroutine-friendly way.
+         * Factory function to create a new CoreCryptoClient.
+         */
+        suspend fun create(
+            appClientId: AppClientId,
+            ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER,
+            mlsTransport: MlsTransport
+        ): CoreCryptoClient {
+            val ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
+            val clientDirectoryPath = "cryptography/${appClientId.value}"
+            val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
+
+            File(clientDirectoryPath).mkdirs()
+
+            val coreCrypto = CoreCrypto.invoke(
                 keystore = keystorePath,
                 databaseKey = IsolatedKoinContext.getCryptographyStoragePassword()
                     ?: throw InvalidParameter("Cryptography password missing")
             )
+
             coreCrypto.transaction {
                 it.mlsInit(
                     ClientId(appClientId.value),
                     Ciphersuites(setOf(ciphersuite))
                 )
             }
+
             coreCrypto.provideTransport(mlsTransport)
+
+            return CoreCryptoClient(appClientId, ciphersuite, coreCrypto)
+        }
+
+        private fun getMlsCipherSuiteName(code: Int): Ciphersuite {
+            return when (code) {
+                DEFAULT_CIPHERSUITE_IDENTIFIER -> Ciphersuite.DEFAULT
+                2 -> Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+                3 -> Ciphersuite.MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
+                4 -> Ciphersuite.MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
+                5 -> Ciphersuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
+                6 -> Ciphersuite.MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
+                7 -> Ciphersuite.MLS_256_DHKEMP384_AES256GCM_SHA384_P384
+                else -> Ciphersuite.DEFAULT
+            }
         }
     }
 
-    override fun encryptMls(
+    override suspend fun encryptMls(
         mlsGroupId: MLSGroupId,
         plainMessage: ByteArray
     ): ByteArray {
-        val encryptedMessage = runBlocking {
+        val encryptedMessage =
             coreCrypto.transaction { it.encryptMessage(mlsGroupId, PlaintextMessage(plainMessage)) }
-        }
         return encryptedMessage.value
     }
 
-    override fun decryptMls(
+    override suspend fun decryptMls(
         mlsGroupId: MLSGroupId,
         encryptedMessage: String
     ): ByteArray {
         val encryptedMessageBytes: ByteArray = Base64.getDecoder().decode(encryptedMessage)
-        val decryptedMessage = runBlocking {
+        val decryptedMessage =
             coreCrypto.transaction {
                 it.decryptMessage(
                     id = mlsGroupId,
                     message = MlsMessage(encryptedMessageBytes)
                 )
             }
-        }
         return decryptedMessage.message
             ?: throw WireException.CryptographicSystemError("Decryption failed")
     }
 
-    override fun mlsGetPublicKey(): MlsPublicKeys {
-        val key = runBlocking {
+    override suspend fun mlsGetPublicKey(): MlsPublicKeys {
+        val key =
             coreCrypto.transaction {
                 it.getPublicKey(ciphersuite = ciphersuite).value
             }
-        }
         val encodedKey = Base64.getEncoder().encodeToString(key)
         return when (ciphersuite) {
             Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256 -> {
@@ -112,84 +146,52 @@ internal class CoreCryptoClient : CryptoClient {
         }
     }
 
-    override fun mlsGenerateKeyPackages(packageCount: UInt): List<MLSKeyPackage> {
-        return runBlocking {
-            coreCrypto.transaction {
-                it.generateKeyPackages(
-                    amount = packageCount,
-                    ciphersuite = ciphersuite
-                )
-            }
+    override suspend fun mlsGenerateKeyPackages(packageCount: UInt): List<MLSKeyPackage> {
+        return coreCrypto.transaction {
+            it.generateKeyPackages(
+                amount = packageCount,
+                ciphersuite = ciphersuite
+            )
         }
     }
 
-    override fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean {
-        return runBlocking {
-            coreCrypto.transaction { it.conversationExists(mlsGroupId) }
+    override suspend fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean {
+        return coreCrypto.transaction { it.conversationExists(mlsGroupId) }
+    }
+
+    override suspend fun joinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId {
+        return coreCrypto.transaction { it.joinByExternalCommit(groupInfo).id }
+    }
+
+    override suspend fun createConversation(groupId: MLSGroupId) {
+        return coreCrypto.transaction {
+            it.createConversation(
+                id = groupId,
+                ciphersuite = ciphersuite
+            )
         }
     }
 
-    override fun createJoinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId {
-        return runBlocking {
-            coreCrypto.transaction { it.joinByExternalCommit(groupInfo).id }
-        }
-    }
-
-    override fun createConversation(groupId: MLSGroupId) {
-        return runBlocking {
-            coreCrypto.transaction {
-                it.createConversation(
-                    id = groupId,
-                    ciphersuite = ciphersuite
-                )
-            }
-        }
-    }
-
-    override fun addMemberToMlsConversation(
+    override suspend fun addMemberToMlsConversation(
         mlsGroupId: MLSGroupId,
         keyPackages: List<MLSKeyPackage>
     ) {
-        runBlocking {
-            coreCrypto.transaction {
-                it.addMember(mlsGroupId, keyPackages)
-            }
+        coreCrypto.transaction {
+            it.addMember(mlsGroupId, keyPackages)
         }
     }
 
-    override fun processWelcomeMessage(welcome: Welcome): MLSGroupId {
-        val welcomeBundle = runBlocking {
-            coreCrypto.transaction { it.processWelcomeMessage(welcome) }
-        }
+    override suspend fun processWelcomeMessage(welcome: Welcome): MLSGroupId {
+        val welcomeBundle = coreCrypto.transaction { it.processWelcomeMessage(welcome) }
         return welcomeBundle.id
     }
 
-    override fun validKeyPackageCount(): Long {
-        val packageCount = runBlocking {
-            coreCrypto.transaction { it.validKeyPackageCount(ciphersuite) }
-        }
+    override suspend fun validKeyPackageCount(): Long {
+        val packageCount = coreCrypto.transaction { it.validKeyPackageCount(ciphersuite) }
         return packageCount.toLong()
     }
 
     override fun close() {
         runBlocking { coreCrypto.close() }
-    }
-
-    private fun getMlsCipherSuiteName(code: Int): Ciphersuite {
-        return when (code) {
-            DEFAULT_CIPHERSUITE_IDENTIFIER -> Ciphersuite.DEFAULT
-            2 -> Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            3 -> Ciphersuite.MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            4 -> Ciphersuite.MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
-            5 -> Ciphersuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
-            6 -> Ciphersuite.MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
-            7 -> Ciphersuite.MLS_256_DHKEMP384_AES256GCM_SHA384_P384
-            else -> Ciphersuite.DEFAULT
-        }
-    }
-
-    companion object {
-        private const val DEFAULT_CIPHERSUITE_IDENTIFIER = 1
-        private const val KEYSTORE_NAME = "keystore"
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
@@ -23,39 +23,41 @@ import com.wire.crypto.Welcome
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
 
 internal interface CryptoClient : AutoCloseable {
-    fun encryptMls(
+    suspend fun encryptMls(
         mlsGroupId: MLSGroupId,
         plainMessage: ByteArray
     ): ByteArray
 
-    fun decryptMls(
+    suspend fun decryptMls(
         mlsGroupId: MLSGroupId,
         encryptedMessage: String
     ): ByteArray
 
-    fun mlsGetPublicKey(): MlsPublicKeys
+    suspend fun mlsGetPublicKey(): MlsPublicKeys
 
-    fun mlsGenerateKeyPackages(packageCount: UInt = DEFAULT_KEYPACKAGE_COUNT): List<MLSKeyPackage>
+    suspend fun mlsGenerateKeyPackages(
+        packageCount: UInt = DEFAULT_KEYPACKAGE_COUNT
+    ): List<MLSKeyPackage>
 
-    fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean
+    suspend fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean
 
     /**
      * Create a request to join an MLS conversation.
      * Needs to be followed by a call to markMlsConversationAsJoined() to complete the process.
      */
-    fun createJoinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId
+    suspend fun joinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId
 
     /**
      * Create an MLS conversation, adding the client as the first member.
      */
-    fun createConversation(groupId: MLSGroupId)
+    suspend fun createConversation(groupId: MLSGroupId)
 
     /**
      * Alternative way to add a member to an MLS conversation.
      * Instead of creating a join request accepted by the new client,
      * this method directly adds a member to a conversation.
      */
-    fun addMemberToMlsConversation(
+    suspend fun addMemberToMlsConversation(
         mlsGroupId: MLSGroupId,
         keyPackages: List<MLSKeyPackage>
     )
@@ -63,9 +65,9 @@ internal interface CryptoClient : AutoCloseable {
     /**
      * Process an MLS welcome message, adding this client to a conversation, and return the groupId.
      */
-    fun processWelcomeMessage(welcome: Welcome): MLSGroupId
+    suspend fun processWelcomeMessage(welcome: Welcome): MLSGroupId
 
-    fun validKeyPackageCount(): Long
+    suspend fun validKeyPackageCount(): Long
 
     companion object {
         const val DEFAULT_KEYPACKAGE_COUNT = 100u

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -42,7 +42,7 @@ internal class EventsRouter internal constructor(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    internal fun route(
+    internal suspend fun route(
         eventResponse: EventResponse,
         cryptoClient: CryptoClient
     ) {
@@ -109,7 +109,7 @@ internal class EventsRouter internal constructor(
      * Orphan welcomes are recovered by sending a join request to the Backend,
      * which still returns the groupId after accepting the proposal.
      */
-    private fun fetchGroupIdFromWelcome(
+    private suspend fun fetchGroupIdFromWelcome(
         cryptoClient: CryptoClient,
         welcome: Welcome,
         event: EventContentDTO.Conversation.MlsWelcome
@@ -121,7 +121,7 @@ internal class EventsRouter internal constructor(
                 logger.info("Cannot process welcome, ask to join the conversation")
                 val groupInfo =
                     backendClient.getConversationGroupInfo(event.qualifiedConversation)
-                cryptoClient.createJoinMlsConversationRequest(GroupInfo(groupInfo))
+                cryptoClient.joinMlsConversationRequest(GroupInfo(groupInfo))
             } else {
                 logger.error("Cannot process welcome", ex)
                 throw WireException.CryptographicSystemError("Cannot process welcome")
@@ -133,7 +133,7 @@ internal class EventsRouter internal constructor(
      * Fetches the group ID of the conversation in the local database.
      * If missing, tries to recover it by fetching the conversation from the Backend.
      */
-    private fun fetchGroupIdFromConversation(
+    private suspend fun fetchGroupIdFromConversation(
         event: EventContentDTO.Conversation.NewMLSMessageDTO
     ): MLSGroupId {
         val storedConversation =
@@ -159,7 +159,7 @@ internal class EventsRouter internal constructor(
         }
     }
 
-    private fun newTeamInvite(teamId: TeamId) {
+    private suspend fun newTeamInvite(teamId: TeamId) {
         try {
             backendClient.confirmTeam(teamId)
             teamStorage.save(teamId) // Can be done async ?

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
@@ -23,9 +23,12 @@ import com.wire.integrations.jvm.model.http.ApiVersionResponse
 import com.wire.integrations.jvm.model.http.AppDataResponse
 import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
+import kotlinx.coroutines.runBlocking
 
 /**
  * Allows fetching common data and interacting with each Team instance invited to the Application.
+ * Some functions are provided as blocking methods for Java interoperability or
+ * as suspending methods for Kotlin consumers.
  */
 class WireApplicationManager internal constructor(
     private val teamStorage: TeamStorage,
@@ -36,9 +39,38 @@ class WireApplicationManager internal constructor(
 
     fun getStoredConversations(): List<ConversationData> = conversationStorage.getAll()
 
+    /**
+     * Get API configuration from the connected Wire backend.
+     * Blocking method for Java interoperability
+     */
     @Throws(WireException::class)
-    fun getApplicationMetadata(): ApiVersionResponse = backendClient.getBackendVersion()
+    fun getApplicationMetadata(): ApiVersionResponse =
+        runBlocking {
+            getApplicationMetadataSuspending()
+        }
 
+    /**
+     * Get API configuration from the connected Wire backend.
+     * Suspending method for Kotlin consumers
+     */
     @Throws(WireException::class)
-    fun getApplicationData(): AppDataResponse = backendClient.getApplicationData()
+    suspend fun getApplicationMetadataSuspending(): ApiVersionResponse =
+        backendClient.getBackendVersion()
+
+    /**
+     * Get the basic Wire Application data from the connected Wire backend.
+     * Blocking method for Java interoperability
+     */
+    @Throws(WireException::class)
+    fun getApplicationData(): AppDataResponse =
+        runBlocking {
+            getApplicationDataSuspending()
+        }
+
+    /**
+     * Get the basic Wire Application data from the connected Wire backend.
+     * Suspending method for Kotlin consumers
+     */
+    @Throws(WireException::class)
+    suspend fun getApplicationDataSuspending(): AppDataResponse = backendClient.getApplicationData()
 }


### PR DESCRIPTION
* Use suspend function where possible
* Move Ktor init to Modules.kt
* Change CoreCryptoClient to use a factory, in order to use suspend
* Fix accessToken retrieval in BackendClientDemo

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SDK used runBlocking everywhere, rendering coroutines useless

### Solutions

Use a common scope from the top most runBlocking and then adopt suspend functions everywhere

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
