### PR TITLE
chore: Publish SDK to Maven Central #WPB-17132

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,7 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
       - name: Publish to MavenCentral
-        # publishToMavenCentral - Needs manual check after it was deployed to Maven Central
-        # publishAndReleaseToMavenCentral - Fully automated deployment and publishing, to be used
-        # after first verification.
-        run: ./gradlew publishToMavenCentral --no-configuration-cache --info
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --info
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ lib/cryptography
 *.ipr
 *.iws
 
+# Ignore local environment/properties files
+.env
+
 # Ignore Gradle generated folder
 .kotlin
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
 }
 
 group = "com.wire.integrations"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1"
 val artifactId = "wire-apps-jvm-sdk"
 
 repositories {
@@ -147,6 +147,22 @@ mavenPublishing {
                 name = "The GNU General Public License v3.0"
                 url = "https://www.gnu.org/licenses/gpl-3.0.en.html"
                 distribution = "https://www.gnu.org/licenses/gpl-3.0.en.html"
+            }
+        }
+        developers {
+            developer {
+                id = "alexandreferris"
+                name = "Alexandre Ferris"
+                url = "https://github.com/alexandreferris"
+                organization = "Wire Germany GmbH"
+                organizationUrl = "https://wire.com/"
+            }
+            developer {
+                id = "spoonman01"
+                name = "Luca Rospocher"
+                url = "https://github.com/spoonman01"
+                organization = "Wire Germany GmbH"
+                organizationUrl = "https://wire.com/"
             }
         }
         scm {


### PR DESCRIPTION
* Change publishing command to publishAndReleaseToMavenCentral so it deploys and releases automatically
* Add developers section to mavenPublishing config in Gradle

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing developers section on mavenPublishing configuration

### Causes (Optional)

Was previously removed unaware that it was required

### Solutions

Bring back the developers section on mavenPublishing and change the command to deploy and publish the SDK to maven on `release.yml`
