### PR TITLE
chore: Change SDK group name #WPB-17132

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.31.0"
 }
 
-group = "com.wire.integrations"
+group = "com.wire"
 version = "0.0.1"
 val artifactId = "wire-apps-jvm-sdk"
 


### PR DESCRIPTION
* Change group name from `com.wire.integrations` to `com.wire` to comply with current namespace in Maven Central

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Current group name not complying with company group name for deploying and publishing on Maven Central

### Causes (Optional)

additional `.integrations`

### Solutions

Change group name from `com.wire.integrations` to `com.wire`