### PR TITLE
feat: handle Composite Type Events #WPB-17136

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ by creating a `demo.properties` file in the classpath (e.g. `src/main/resources/
 
 ```kotlin
 dependencies {
-    implementation("com.wire.integrations:wire-apps-jvm-sdk:0.0.1-SNAPSHOT")
+    implementation("com.wire:wire-apps-jvm-sdk:0.0.1")
 }
 ```
 
 ### Maven
 ```xml
 <dependency>
-    <groupId>com.wire.integrations</groupId>
+    <groupId>com.wire</groupId>
     <artifactId>wire-apps-jvm-sdk</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
 </dependency>
 ```
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory
  * Abstract class exposed by the SDK, clients can override the methods in this class and pass it
  * during SDK initialization to handle Wire events.
  */
+@Suppress("TooManyFunctions")
 abstract class WireEventsHandler {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -67,11 +68,39 @@ abstract class WireEventsHandler {
     }
 
     open fun onNewAsset(wireMessage: WireMessage.Asset) {
-        logger.info("Received event: onNewAsset - message content: $wireMessage")
+        logger.info("Received event: onNewAsset")
     }
 
     open suspend fun onNewAssetSuspending(wireMessage: WireMessage.Asset) {
-        logger.info("Received event: onNewAssetSuspending - message content: $wireMessage")
+        logger.info("Received event: onNewAssetSuspending")
+    }
+
+    open fun onNewComposite(wireMessage: WireMessage.Composite) {
+        logger.info("Received event: onNewComposite")
+    }
+
+    open suspend fun onNewCompositeSuspending(wireMessage: WireMessage.Composite) {
+        logger.info("Received event: onNewCompositeSuspending")
+    }
+
+    open suspend fun onNewButtonAction(wireMessage: WireMessage.ButtonAction) {
+        logger.info("Received event: onNewButtonAction")
+    }
+
+    open suspend fun onNewButtonActionSuspending(wireMessage: WireMessage.ButtonAction) {
+        logger.info("Received event: onNewButtonActionSuspending")
+    }
+
+    open suspend fun onNewButtonActionConfirmation(
+        wireMessage: WireMessage.ButtonActionConfirmation
+    ) {
+        logger.info("Received event: onNewButtonActionConfirmation")
+    }
+
+    open suspend fun onNewButtonActionConfirmationSuspending(
+        wireMessage: WireMessage.ButtonActionConfirmation
+    ) {
+        logger.info("Received event: onNewButtonActionConfirmationSuspending: $wireMessage")
     }
 
     /**

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -198,5 +198,124 @@ sealed interface WireMessage {
         }
     }
 
+    @JvmRecord
+    data class Composite(
+        val textContent: Text?,
+        val buttonList: List<Button>
+    ) : WireMessage {
+        data class Button(
+            val text: String,
+            val id: String,
+            val isSelected: Boolean
+        ) {
+            companion object {
+                /**
+                 * Creates a Composite Button message with minimal required parameters.
+                 *
+                 * Usage from Kotlin:
+                 * ```kotlin
+                 * val button = Composite.Button.create(conversationId, "Hello world")
+                 * ```
+                 *
+                 * Usage from Java:
+                 * ```java
+                 * Composite.Button button =
+                 *      Composite.Button.Companion.create(conversationId, "Hello world");
+                 * ```
+                 *
+                 * @param text The text content of the message
+                 * @param isSelected Whether the button is selected.
+                 * @param id Random generated UUID or received ID value.
+                 * @return A new Composite.Button message with a random UUID
+                 */
+                @JvmStatic
+                fun create(
+                    text: String,
+                    isSelected: Boolean,
+                    id: String? = null
+                ): Button {
+                    return Button(
+                        text = text,
+                        isSelected = isSelected,
+                        id = id ?: UUID.randomUUID().toString()
+                    )
+                }
+            }
+        }
+
+        companion object {
+            /**
+             * Creates a Composite message.
+             *
+             * Usage from Kotlin:
+             * ```kotlin
+             * val message = Composite.create(conversationId, "Hello world", buttonList)
+             * ```
+             *
+             * Usage from Java:
+             * ```java
+             * Composite composite =
+             *      Composite.Companion.create(conversationId, "Hello world", buttonList);
+             * ```
+             *
+             * @param conversationId The qualified ID of the conversation
+             * @param text The text content of the message
+             * @param buttonList The list of buttons to be selected
+             * @return A new Composite message
+             */
+            @JvmStatic
+            fun create(
+                conversationId: QualifiedId,
+                text: String,
+                buttonList: List<Button>
+            ): Composite {
+                return Composite(
+                    textContent = Text.create(
+                        conversationId = conversationId,
+                        text = text
+                    ),
+                    buttonList = buttonList
+                )
+            }
+        }
+    }
+
+    /**
+     * Notifies the author of a [Composite] message that a user has
+     * selected one of its buttons.
+     * @see Composite
+     * @see ButtonActionConfirmation
+     */
+    @JvmRecord
+    data class ButtonAction(
+        /**
+         * The ID of the original composite message.
+         */
+        val referencedMessageId: String,
+        /**
+         * ID of the button that was selected.
+         */
+        val buttonId: String
+    ) : WireMessage
+
+    /**
+     * Message sent by the author of a [Composite] to
+     * notify which button should be marked as selected.
+     * For example, after we send [ButtonAction], the author might reply
+     * with [ButtonActionConfirmation] to confirm that the button event was processed.
+     * @see ButtonAction
+     * @see Composite
+     */
+    data class ButtonActionConfirmation(
+        /**
+         * ID fo the original composite message
+         */
+        val referencedMessageId: String,
+        /**
+         * ID of the selected button. Null if no button should be marked as selected.
+         */
+        val buttonId: String?
+    ) : WireMessage
+
     data object Unknown : WireMessage
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufProcessor.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufProcessor.kt
@@ -18,6 +18,7 @@ package com.wire.integrations.jvm.model.protobuf
 
 import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.integrations.jvm.model.WireMessage
+import com.wire.integrations.protobuf.messages.Messages.Composite
 import com.wire.integrations.protobuf.messages.Messages.GenericMessage
 import java.util.UUID
 
@@ -27,88 +28,172 @@ object ProtobufProcessor {
         genericMessage: GenericMessage,
         conversationId: QualifiedId,
         sender: QualifiedId
-    ): WireMessage {
-        if (genericMessage.hasText()) {
-            val text = genericMessage.text
-
-            return WireMessage.Text(
+    ): WireMessage =
+        when {
+            genericMessage.hasText() -> unpackText(
+                genericMessage = genericMessage,
                 conversationId = conversationId,
-                sender = sender,
-                id = UUID.fromString(genericMessage.messageId),
-                text = text.content,
-                quotedMessageId =
-                    if (text.hasQuote()) UUID.fromString(text.quote.quotedMessageId) else null,
-                linkPreviews = text
-                    .linkPreviewList
-                    .mapNotNull {
-                        MessageLinkPreviewMapper.fromProtobuf(it)
-                    },
-                mentions = text
-                    .mentionsList
-                    .mapNotNull {
-                        MessageMentionMapper.fromProtobuf(it)
-                    }
+                sender = sender
             )
+
+            genericMessage.hasAsset() -> unpackAsset(
+                genericMessage = genericMessage,
+                conversationId = conversationId
+            )
+
+            genericMessage.hasComposite() -> unpackComposite(
+                genericMessage = genericMessage,
+                conversationId = conversationId,
+                sender = sender
+            )
+
+            genericMessage.hasButtonAction() -> unpackButtonAction(
+                genericMessage = genericMessage
+            )
+
+            genericMessage.hasButtonActionConfirmation() -> unpackButtonActionConfirmation(
+                genericMessage = genericMessage
+            )
+
+            else -> WireMessage.Unknown
         }
 
-        if (genericMessage.hasAsset()) {
-            val asset = genericMessage.asset
-            val original = asset.original
+    private fun unpackText(
+        genericMessage: GenericMessage,
+        conversationId: QualifiedId,
+        sender: QualifiedId
+    ): WireMessage.Text {
+        val text = genericMessage.text
 
-            val metadata: WireMessage.Asset.AssetMetadata? = when {
-                original?.hasImage() == true -> {
-                    val image = original.image
-                    WireMessage.Asset.AssetMetadata.Image(
-                        width = image.width,
-                        height = image.height
-                    )
+        return WireMessage.Text(
+            conversationId = conversationId,
+            sender = sender,
+            id = UUID.fromString(genericMessage.messageId),
+            text = text.content,
+            quotedMessageId =
+                if (text.hasQuote()) UUID.fromString(text.quote.quotedMessageId) else null,
+            linkPreviews = text
+                .linkPreviewList
+                .mapNotNull {
+                    MessageLinkPreviewMapper.fromProtobuf(it)
+                },
+            mentions = text
+                .mentionsList
+                .mapNotNull {
+                    MessageMentionMapper.fromProtobuf(it)
                 }
-                original?.hasAudio() == true -> {
-                    val audio = original.audio
-                    WireMessage.Asset.AssetMetadata.Audio(
-                        durationMs = audio.durationInMillis,
-                        normalizedLoudness = audio.normalizedLoudness?.toByteArray()
-                    )
-                }
-                original?.hasVideo() == true -> {
-                    val video = original.video
-                    WireMessage.Asset.AssetMetadata.Video(
-                        width = video.width,
-                        height = video.height,
-                        durationMs = video.durationInMillis
-                    )
-                }
-
-                else -> null
-            }
-
-            val remoteData = if (asset.hasUploaded()) {
-                val uploadedAsset = asset.uploaded
-
-                WireMessage.Asset.AssetMetadata.RemoteData(
-                    otrKey = uploadedAsset.otrKey.toByteArray(),
-                    sha256 = uploadedAsset.sha256.toByteArray(),
-                    assetId = uploadedAsset.assetId,
-                    assetDomain = uploadedAsset.assetDomain,
-                    assetToken = uploadedAsset.assetToken,
-                    encryptionAlgorithm = EncryptionAlgorithmMapper.fromProtobufModel(
-                        encryptionAlgorithm = uploadedAsset.encryption
-                    )
-                )
-            } else {
-                null
-            }
-
-            return WireMessage.Asset(
-                conversationId = conversationId,
-                sizeInBytes = original?.size ?: 0,
-                name = original?.name,
-                mimeType = original?.mimeType ?: "*/*",
-                metadata = metadata,
-                remoteData = remoteData
-            )
-        }
-
-        return WireMessage.Unknown
+        )
     }
+
+    private fun unpackAsset(
+        genericMessage: GenericMessage,
+        conversationId: QualifiedId
+    ): WireMessage.Asset {
+        val asset = genericMessage.asset
+        val original = asset.original
+
+        val metadata: WireMessage.Asset.AssetMetadata? = when {
+            original?.hasImage() == true -> {
+                val image = original.image
+                WireMessage.Asset.AssetMetadata.Image(
+                    width = image.width,
+                    height = image.height
+                )
+            }
+
+            original?.hasAudio() == true -> {
+                val audio = original.audio
+                WireMessage.Asset.AssetMetadata.Audio(
+                    durationMs = audio.durationInMillis,
+                    normalizedLoudness = audio.normalizedLoudness?.toByteArray()
+                )
+            }
+
+            original?.hasVideo() == true -> {
+                val video = original.video
+                WireMessage.Asset.AssetMetadata.Video(
+                    width = video.width,
+                    height = video.height,
+                    durationMs = video.durationInMillis
+                )
+            }
+
+            else -> null
+        }
+
+        val remoteData = if (asset.hasUploaded()) {
+            val uploadedAsset = asset.uploaded
+
+            WireMessage.Asset.AssetMetadata.RemoteData(
+                otrKey = uploadedAsset.otrKey.toByteArray(),
+                sha256 = uploadedAsset.sha256.toByteArray(),
+                assetId = uploadedAsset.assetId,
+                assetDomain = uploadedAsset.assetDomain,
+                assetToken = uploadedAsset.assetToken,
+                encryptionAlgorithm = EncryptionAlgorithmMapper.fromProtobufModel(
+                    encryptionAlgorithm = uploadedAsset.encryption
+                )
+            )
+        } else {
+            null
+        }
+
+        return WireMessage.Asset(
+            conversationId = conversationId,
+            sizeInBytes = original?.size ?: 0,
+            name = original?.name,
+            mimeType = original?.mimeType ?: "*/*",
+            metadata = metadata,
+            remoteData = remoteData
+        )
+    }
+
+    private fun unpackComposite(
+        genericMessage: GenericMessage,
+        conversationId: QualifiedId,
+        sender: QualifiedId
+    ): WireMessage.Composite {
+        val items = genericMessage.composite.itemsList
+        val text = items.firstNotNullOfOrNull { item ->
+            item.text
+        }?.let {
+            unpackText(
+                genericMessage = genericMessage,
+                conversationId = conversationId,
+                sender = sender
+            )
+        }
+
+        val buttonList = unpackButtonList(items)
+
+        return WireMessage.Composite(
+            textContent = text,
+            buttonList = buttonList
+        )
+    }
+
+    private fun unpackButtonList(
+        compositeItemList: List<Composite.Item>
+    ): List<WireMessage.Composite.Button> =
+        compositeItemList.mapNotNull {
+            it.button?.let { button ->
+                WireMessage.Composite.Button(
+                    text = button.text,
+                    id = button.id,
+                    isSelected = false
+                )
+            }
+        }
+
+    private fun unpackButtonAction(genericMessage: GenericMessage): WireMessage =
+        WireMessage.ButtonAction(
+            referencedMessageId = genericMessage.buttonAction.referenceMessageId,
+            buttonId = genericMessage.buttonAction.buttonId
+        )
+
+    private fun unpackButtonActionConfirmation(genericMessage: GenericMessage): WireMessage =
+        WireMessage.ButtonActionConfirmation(
+            referencedMessageId = genericMessage.buttonActionConfirmation.referenceMessageId,
+            buttonId = genericMessage.buttonActionConfirmation.buttonId
+        )
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -151,6 +151,20 @@ internal class EventsRouter internal constructor(
                             wireMessage = wireMessage
                         )
 
+                        is WireMessage.Composite -> wireEventsHandler.onNewCompositeSuspending(
+                            wireMessage = wireMessage
+                        )
+
+                        is WireMessage.ButtonAction ->
+                            wireEventsHandler.onNewButtonActionSuspending(
+                                wireMessage = wireMessage
+                            )
+
+                        is WireMessage.ButtonActionConfirmation ->
+                            wireEventsHandler.onNewButtonActionConfirmationSuspending(
+                                wireMessage = wireMessage
+                            )
+
                         WireMessage.Unknown -> {
                             logger.warn("Unknown event received.")
                         }

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -67,6 +67,24 @@ fun main() {
                     logger.info("Downloaded asset in ByteArray: $asset")
                 }
             }
+
+            override suspend fun onNewCompositeSuspending(wireMessage: WireMessage.Composite) {
+                logger.info("Received Composite Message : $wireMessage")
+
+                logger.info("Received Composite Title: ${wireMessage.textContent?.text}")
+                logger.info("Received Composite Buttons:")
+                wireMessage.buttonList.forEach {
+                    logger.info("Composite Buttons: ${it.text} | isSelected: ${it.isSelected}")
+                }
+            }
+
+            override suspend fun onNewButtonActionSuspending(wireMessage: WireMessage.ButtonAction) {
+                logger.info("Received ButtonAction Message : $wireMessage")
+            }
+
+            override suspend fun onNewButtonActionConfirmationSuspending(wireMessage: WireMessage.ButtonActionConfirmation) {
+                logger.info("Received ButtonActionConfirmation Message : $wireMessage")
+            }
         }
     )
 


### PR DESCRIPTION
* Adjust gradle/maven dependency for SDK
* Add Composite, ActionButton and ActionButtonConfirmation for WireMessage types
* Add receiving and sending of above events

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no handling for Composite, ButtonAction and ButtonActionConfirmation event type

### Causes (Optional)

Not implemented yet.

### Solutions

Add WireMessage type, sending and receiving for Composite, ButtonAction and ButtonActionConfirmation event type
