### PR TITLE
feat: add sender and conversation id to button action #WPB-17500

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -288,6 +288,7 @@ sealed interface WireMessage {
      */
     @JvmRecord
     data class ButtonAction(
+        val conversationId: QualifiedId,
         /**
          * The ID of the original composite message.
          */
@@ -295,7 +296,8 @@ sealed interface WireMessage {
         /**
          * ID of the button that was selected.
          */
-        val buttonId: String
+        val buttonId: String,
+        val sender: QualifiedId
     ) : WireMessage
 
     /**

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufProcessor.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufProcessor.kt
@@ -48,7 +48,9 @@ object ProtobufProcessor {
             )
 
             genericMessage.hasButtonAction() -> unpackButtonAction(
-                genericMessage = genericMessage
+                genericMessage = genericMessage,
+                conversationId = conversationId,
+                sender = sender
             )
 
             genericMessage.hasButtonActionConfirmation() -> unpackButtonActionConfirmation(
@@ -185,10 +187,16 @@ object ProtobufProcessor {
             }
         }
 
-    private fun unpackButtonAction(genericMessage: GenericMessage): WireMessage =
+    private fun unpackButtonAction(
+        genericMessage: GenericMessage,
+        conversationId: QualifiedId,
+        sender: QualifiedId
+    ): WireMessage =
         WireMessage.ButtonAction(
             referencedMessageId = genericMessage.buttonAction.referenceMessageId,
-            buttonId = genericMessage.buttonAction.buttonId
+            buttonId = genericMessage.buttonAction.buttonId,
+            conversationId = conversationId,
+            sender = sender
         )
 
     private fun unpackButtonActionConfirmation(genericMessage: GenericMessage): WireMessage =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Possibility of multiple votes from same user.
- Developer needs to save composite message id to react to button action.

### Solutions

Add missing values to the button action.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
