### PR TITLE
chore: Refactoring WireMessage, simplifying classes, fixing Composite, adding @JvmOverloads #WPB-17515

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,7 @@ messages to it.
 
 ## How to use it
 
-### Wire dev
-
-You can define the implementation of BackendClient to use, by changing it in the Modules.kt file.
-
-* BackendClientDemo targets the Wire backend for development purposes, it uses the Client API for
-  testing instead of the Application API
-* BackendClientImpl is the real implementation of the SDK, targeting the Wire backend as an
-  Application
-
-For the demo setup, some default properties are there, you can override those values
-by creating a `demo.properties` file in the classpath (e.g. `src/main/resources/demo.properties`).
+For information about usage and onboarding refer to [Sdk tutorial](docs/APPLICATION.md).
 
 ## Requirements
 
@@ -78,3 +68,15 @@ dependencies {
 
 If you have started using the SDK targeting one Wire environment,
 and later you want to switch to another, you may need to move/delete the `apps.db` directory
+
+### Testing the SDK
+
+You can define the implementation of BackendClient to use, by changing it in the Modules.kt file.
+
+* BackendClientDemo targets the Wire backend for development purposes, it uses the Client API for
+  testing instead of the Application API
+* BackendClientImpl is the real implementation of the SDK, targeting the Wire backend as an
+  Application
+
+For the demo setup, some default properties are there, you can override those values
+by creating a `demo.properties` file in the classpath (e.g. `src/main/resources/demo.properties`).

--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -8,6 +8,7 @@ Note that the SDK takes care of security in transit and partially for securing c
 ## Prerequisites
 
 - Java 17 or higher
+- Kotlin 2.x.x if you are using Kotlin
 - An application registered with Wire (to obtain an API token)
 - File system access for storing cryptographic keys and data
 
@@ -80,11 +81,6 @@ The SDK uses the `WireEventsHandler` to notify your application about events and
 Here's a complete example showing how to initialize the SDK and handle received events:
 
 ```kotlin
-import com.wire.integrations.jvm.WireAppSdk
-import com.wire.integrations.jvm.WireEventsHandler
-import com.wire.integrations.jvm.model.WireMessage
-import java.util.UUID
-
 fun main() {
     val wireAppSdk = WireAppSdk(
         applicationId = "9c40bb37-6904-11ef-8008-be4b58ff1d17",
@@ -103,6 +99,17 @@ fun main() {
     
     // Start the SDK
     wireAppSdk.startListening()
+}
+```
+For simplicity the subclassing of WireEventsHandler is done inline as an anonymous class, but you can create a separate class for it,
+especially if you handle events in a complex way:
+```kotlin
+class MyWireEventsHandler : WireEventsHandler() {
+    private val logger = LoggerFactory.getLogger(MyWireEventsHandler::class.java)
+
+    override fun onNewMessage(wireMessage: WireMessage.Text) {
+        logger.info("Message received: $wireMessage")
+    }
 }
 ```
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandler.kt
@@ -50,8 +50,10 @@ abstract class WireEventsHandler {
     }
 
     /**
-     * One or more users have joined a conversation accessible by the Wire App.
-     * This can be new users or your Wire App itself just joining a conversation
+     * The app has been added to a conversation.
+     *
+     * @param conversation the conversation id with some extra data
+     * @param members the members that got added, including the app and possibly other users
      */
     open fun onConversationJoin(
         conversation: ConversationData,
@@ -105,8 +107,7 @@ abstract class WireEventsHandler {
 
     /**
      * One or more users have joined a conversation accessible by the Wire App.
-     * This event is triggered when the App is already in the conversation and new users joins,
-     * or when other users join the conversation at the same time as the App.
+     * This event is triggered when the App is already in the conversation and new users joins.
      */
     open fun onMemberJoin(
         conversationId: QualifiedId,

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 interface BackendClient {
     suspend fun connectWebSocket(handleFrames: suspend (ReceiveChannel<Frame>) -> Unit)
 
-    suspend fun getBackendVersion(): ApiVersionResponse
+    suspend fun getAvailableApiVersions(): ApiVersionResponse
 
     suspend fun getApplicationData(): AppDataResponse
 
@@ -69,4 +69,8 @@ interface BackendClient {
         encryptedFileLength: Long,
         assetUploadData: AssetUploadData
     ): AssetUploadResponse
+
+    companion object {
+        const val API_VERSION = "v8"
+    }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
@@ -16,6 +16,7 @@
 
 package com.wire.integrations.jvm.client
 
+import com.wire.integrations.jvm.client.BackendClient.Companion.API_VERSION
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.exception.runWithWireException
 import com.wire.integrations.jvm.model.AppClientId
@@ -91,7 +92,7 @@ internal class BackendClientDemo internal constructor(
         }
     }
 
-    override suspend fun getBackendVersion(): ApiVersionResponse {
+    override suspend fun getAvailableApiVersions(): ApiVersionResponse {
         logger.info("Fetching Wire backend version")
         return runWithWireException {
             httpClient.get("/$API_VERSION/api-version").body()
@@ -334,7 +335,6 @@ internal class BackendClientDemo internal constructor(
     }
 
     private companion object {
-        const val API_VERSION = "v7"
         const val PATH_PUBLIC_ASSETS_V3 = "assets/v3"
         const val PATH_PUBLIC_ASSETS_V4 = "assets/v4"
         const val HEADER_ASSET_TOKEN = "Asset-Token"

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
@@ -16,6 +16,7 @@
 
 package com.wire.integrations.jvm.client
 
+import com.wire.integrations.jvm.client.BackendClient.Companion.API_VERSION
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.exception.runWithWireException
 import com.wire.integrations.jvm.model.AppClientId
@@ -60,7 +61,7 @@ internal class BackendClientImpl internal constructor(
         }
     }
 
-    override suspend fun getBackendVersion(): ApiVersionResponse {
+    override suspend fun getAvailableApiVersions(): ApiVersionResponse {
         logger.info("Fetching Wire backend version")
         return runWithWireException {
             httpClient.get("/$API_VERSION/api-version").body()
@@ -132,9 +133,5 @@ internal class BackendClientImpl internal constructor(
         assetUploadData: AssetUploadData
     ): AssetUploadResponse {
         TODO("Not yet implemented")
-    }
-
-    companion object {
-        private const val API_VERSION = "v7"
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -32,7 +32,7 @@ import com.wire.integrations.jvm.model.TeamId
 import com.wire.integrations.jvm.model.WireMessage
 import com.wire.integrations.jvm.model.http.EventContentDTO
 import com.wire.integrations.jvm.model.http.EventResponse
-import com.wire.integrations.jvm.model.protobuf.ProtobufProcessor
+import com.wire.integrations.jvm.model.protobuf.ProtobufDeserializer
 import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
 import com.wire.integrations.protobuf.messages.Messages.GenericMessage
@@ -139,7 +139,7 @@ internal class EventsRouter internal constructor(
                     }
 
                     val genericMessage = GenericMessage.parseFrom(message)
-                    val wireMessage = ProtobufProcessor.processGenericMessage(
+                    val wireMessage = ProtobufDeserializer.processGenericMessage(
                         genericMessage = genericMessage,
                         conversationId = event.qualifiedConversation,
                         sender = event.qualifiedFrom

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
@@ -30,7 +30,7 @@ import com.wire.integrations.jvm.model.asset.AssetRetention
 import com.wire.integrations.jvm.model.asset.AssetUploadData
 import com.wire.integrations.jvm.model.http.ApiVersionResponse
 import com.wire.integrations.jvm.model.http.AppDataResponse
-import com.wire.integrations.jvm.model.protobuf.ProtobufMapper
+import com.wire.integrations.jvm.model.protobuf.ProtobufSerializer
 import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
 import com.wire.integrations.jvm.utils.AESDecrypt
@@ -73,7 +73,7 @@ class WireApplicationManager internal constructor(
      */
     @Throws(WireException::class)
     suspend fun getBackendConfigurationSuspending(): ApiVersionResponse =
-        backendClient.getBackendVersion()
+        backendClient.getAvailableApiVersions()
 
     /**
      * Get the basic Wire Application data from the connected Wire backend.
@@ -142,7 +142,7 @@ class WireApplicationManager internal constructor(
             backendClient.sendMessage(
                 mlsMessage = cryptoClient.encryptMls(
                     mlsGroupId = mlsGroupId,
-                    message = ProtobufMapper.toGenericMessageByteArray(wireMessage = message)
+                    message = ProtobufSerializer.toGenericMessageByteArray(wireMessage = message)
                 )
             )
         } ?: throw WireException.EntityNotFound("Couldn't find Conversation MLS Group ID")

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
@@ -21,12 +21,15 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
+import com.wire.integrations.jvm.client.BackendClient
 import java.util.UUID
 
 object TestUtils {
+    const val V = BackendClient.API_VERSION
+
     fun setupWireMockStubs(wireMockServer: WireMockServer) {
         wireMockServer.stubFor(
-            WireMock.get(WireMock.urlMatching("/v7/apps")).willReturn(
+            WireMock.get(WireMock.urlMatching("/$V/apps")).willReturn(
                 WireMock.okJson(
                     """
                     {
@@ -39,7 +42,7 @@ object TestUtils {
             )
         )
         wireMockServer.stubFor(
-            WireMock.post(WireMock.urlMatching("/v7/clients")).willReturn(
+            WireMock.post(WireMock.urlMatching("/$V/clients")).willReturn(
                 WireMock.okJson(
                     """
                     {
@@ -50,7 +53,7 @@ object TestUtils {
             )
         )
         wireMockServer.stubFor(
-            WireMock.post(WireMock.urlMatching("/v7/login")).willReturn(
+            WireMock.post(WireMock.urlMatching("/$V/login")).willReturn(
                 WireMock.okJson(
                     """
                     {
@@ -62,7 +65,7 @@ object TestUtils {
             )
         )
         wireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo("/v7/access"))
+            WireMock.post(WireMock.urlPathEqualTo("/$V/access"))
                 .withQueryParam("client_id", WireMock.matching(".*")).willReturn(
                     WireMock.okJson(
                         """
@@ -75,7 +78,7 @@ object TestUtils {
                 )
         )
         wireMockServer.stubFor(
-            WireMock.get(WireMock.urlMatching("/v7/feature-configs")).willReturn(
+            WireMock.get(WireMock.urlMatching("/$V/feature-configs")).willReturn(
                 WireMock.okJson(
                     """
                     {
@@ -94,13 +97,13 @@ object TestUtils {
             )
         )
         wireMockServer.stubFor(
-            WireMock.put(WireMock.urlPathTemplate("/v7/clients/{appClientId}")).willReturn(
+            WireMock.put(WireMock.urlPathTemplate("/$V/clients/{appClientId}")).willReturn(
                 ok()
             )
         )
         wireMockServer.stubFor(
             WireMock.post(
-                WireMock.urlPathTemplate("/v7/mls/key-packages/self/{appClientId}")
+                WireMock.urlPathTemplate("/$V/mls/key-packages/self/{appClientId}")
             ).willReturn(ok())
         )
     }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
@@ -17,6 +17,7 @@ package com.wire.integrations.jvm
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.wire.integrations.jvm.TestUtils.V
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.model.WireMessage
 import org.junit.jupiter.api.AfterAll
@@ -53,7 +54,7 @@ class WireAppSdkTest : KoinTest {
     @Test
     fun fetchingApiVersionWithWireMockReturnsDummyData() {
         wireMockServer.stubFor(
-            WireMock.get(WireMock.urlMatching("/v7/api-version")).willReturn(
+            WireMock.get(WireMock.urlMatching("/$V/api-version")).willReturn(
                 WireMock.okJson(
                     """
                     {

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
@@ -10,8 +10,8 @@ import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.model.AppClientId
 import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.integrations.jvm.model.WireMessage
-import com.wire.integrations.jvm.model.protobuf.ProtobufMapper
-import com.wire.integrations.jvm.model.protobuf.ProtobufProcessor
+import com.wire.integrations.jvm.model.protobuf.ProtobufDeserializer
+import com.wire.integrations.jvm.model.protobuf.ProtobufSerializer
 import com.wire.integrations.jvm.utils.MlsTransportLastWelcome
 import com.wire.integrations.protobuf.messages.Messages.GenericMessage
 import kotlinx.coroutines.runBlocking
@@ -92,7 +92,7 @@ class CoreCryptoClientTest : KoinTest {
             val encryptedMessage: ByteArray =
                 mlsClient.encryptMls(
                     groupIdGenerated,
-                    ProtobufMapper.toGenericMessageByteArray(wireMessage = wireTextMessage)
+                    ProtobufSerializer.toGenericMessageByteArray(wireMessage = wireTextMessage)
                 )
             assertTrue { encryptedMessage.size > 10 }
             val encryptedBase64Message = Base64.getEncoder().encodeToString(encryptedMessage)
@@ -147,7 +147,7 @@ class CoreCryptoClientTest : KoinTest {
             val encryptedMessage: ByteArray =
                 aliceClient.encryptMls(
                     groupId,
-                    ProtobufMapper.toGenericMessageByteArray(wireMessage = wireTextMessage)
+                    ProtobufSerializer.toGenericMessageByteArray(wireMessage = wireTextMessage)
                 )
             assert(encryptedMessage.size > 10)
             val encryptedBase64Message = Base64.getEncoder().encodeToString(encryptedMessage)
@@ -156,7 +156,7 @@ class CoreCryptoClientTest : KoinTest {
             val decrypted: ByteArray? = bobClient.decryptMls(groupId, encryptedBase64Message)
 
             val genericMessage = GenericMessage.parseFrom(decrypted)
-            val wireMessage = ProtobufProcessor.processGenericMessage(
+            val wireMessage = ProtobufDeserializer.processGenericMessage(
                 genericMessage = genericMessage,
                 conversationId = QualifiedId(
                     id = UUID.randomUUID(),

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -25,6 +25,7 @@ import com.wire.crypto.MLSKeyPackage
 import com.wire.crypto.MlsException
 import com.wire.crypto.Welcome
 import com.wire.integrations.jvm.TestUtils
+import com.wire.integrations.jvm.TestUtils.V
 import com.wire.integrations.jvm.WireEventsHandler
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.crypto.CryptoClient
@@ -404,7 +405,7 @@ class WireEventsIntegrationTest : KoinTest {
             wireMockServer.start()
 
             // Mock conversation fetching
-            val stubConvPath = "/v7/conversations/{CONVERSATION_DOMAIN}/{CONVERSATION_ID}"
+            val stubConvPath = "/$V/conversations/{CONVERSATION_DOMAIN}/{CONVERSATION_ID}"
             wireMockServer.stubFor(
                 WireMock.get(WireMock.urlPathTemplate(stubConvPath)).willReturn(
                     WireMock.okJson(
@@ -435,7 +436,7 @@ class WireEventsIntegrationTest : KoinTest {
                 )
             )
             val stubConvGroupInfoPath =
-                "/v7/conversations/{CONVERSATION_DOMAIN}/{CONVERSATION_ID}/groupinfo"
+                "/$V/conversations/{CONVERSATION_DOMAIN}/{CONVERSATION_ID}/groupinfo"
             wireMockServer.stubFor(
                 WireMock.get(WireMock.urlPathTemplate(stubConvGroupInfoPath))
                     .willReturn(

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -87,10 +87,9 @@ fun main() {
             override suspend fun onNewCompositeSuspending(wireMessage: WireMessage.Composite) {
                 logger.info("Received Composite Message : $wireMessage")
 
-                logger.info("Received Composite Title: ${wireMessage.textContent?.text}")
-                logger.info("Received Composite Buttons:")
-                wireMessage.buttonList.forEach {
-                    logger.info("Composite Buttons: ${it.text} | isSelected: ${it.isSelected}")
+                logger.info("Received Composite Items:")
+                wireMessage.items.forEach {
+                    logger.info("Composite Item: $it")
                 }
             }
 


### PR DESCRIPTION
* Bump backend API to v8, put version in a single place
* Rename Protobuf classes

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

WireMessage had some id properties duplicated or missing and Composite allowed only 1 text item

### Solutions

Refactor WireMessage

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
