### PR TITLE
chore: Publish to Maven Local #WPB-17512

### DIFF
--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -204,6 +204,13 @@ You can take the artifacts built from your Application and run it in any server,
 
 For example, giving that the app does not need HTTPS, DNS, CDN, simpler deployment processes are available, for example: [Heroku - Java](https://devcenter.heroku.com/articles/getting-started-with-java)
 
+## Building Locally
+In case you need to build the SDK locally, you can skip the signing option by running:
+```bash
+./gradlew publishToMavenLocal -PskipSigning=true
+```
+> **_Keep in mind_** to include `repositories { mavenCentral() }` in your `build.gradle.kts` file.
+
 ## Troubleshooting
 
 - Enable DEBUG logging on the SDK if you are developing an Application and want to test it in a safe environment. Set the log level to DEBUG in your logging framework for the package `com.wire.integrations.jvm` (e.g. for Logback `<logger name="com.wire.integrations.jvm" level="DEBUG" />`).

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -132,7 +132,15 @@ protobuf {
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
-    signAllPublications()
+    /**
+     * Skip signing publication only when a skipping parameter is available
+     *
+     * Usage:
+     * ./gradlew publishToMavenLocal -PskipSigning=true
+     */
+    if (findProperty("skipSigning") != "true") {
+        signAllPublications()
+    }
 
     coordinates(group.toString(), artifactId, version.toString())
 


### PR DESCRIPTION
* Change APPLICATION.md to include instructions on how to build locally with skipping signing
* Add extra parameter when calling `./gradlew publishToMavenLocal` to skip signing

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was issue with publication signing when building the SDK locally.

### Causes (Optional)

We require signing on all publications

### Solutions

Add optional parameter to skip signing options when building locally with `./gradlew publishToMavenLocal`

### Testing

#### How to Test

In your SDK Terminal run :
```
./gradlew publishToMavenLocal -PskipSigning=true
```

then check your `~/.m2/repository/com/wire/wire-apps-jvm-sdk/` folder to see if the version you built is correctly there.

### Notes (Optional)

The default (without parameter or any other value) will be have signing required.
