### PR TITLE
chore: Refactor WireEventsHandler, split into 2 classes #WPB-17207

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:EventsRouter.kt$EventsRouter$@Suppress("LongMethod") internal suspend fun route(eventResponse: EventResponse)</ID>
+    <ID>CyclomaticComplexMethod:EventsRouter.kt$EventsRouter$suspend fun forwardMessage( message: ByteArray, conversationId: QualifiedId, sender: QualifiedId )</ID>
     <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$3</ID>
     <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$4</ID>
     <ID>MagicNumber:CoreCryptoClient.kt$CoreCryptoClient.Companion$5</ID>

--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -88,7 +88,7 @@ fun main() {
         apiHost = "https://your-wire-backend.example.com",
         cryptographyStoragePassword = "secure-password",
         object : WireEventsHandler() {
-            override fun onNewMessage(wireMessage: WireMessage) {
+            override fun onMessage(wireMessage: WireMessage) {
                 println("Message received: $wireMessage")
                 
                 // Add your message handling logic here, like storing the message,
@@ -107,7 +107,7 @@ especially if you handle events in a complex way:
 class MyWireEventsHandler : WireEventsHandler() {
     private val logger = LoggerFactory.getLogger(MyWireEventsHandler::class.java)
 
-    override fun onNewMessage(wireMessage: WireMessage.Text) {
+    override fun onMessage(wireMessage: WireMessage.Text) {
         logger.info("Message received: $wireMessage")
     }
 }
@@ -151,7 +151,7 @@ This is done inside the method override of `WireEventsHandler` using a local `ma
 
 #### Text
 ```kotlin
-override suspend fun onNewMessageSuspending(wireMessage: WireMessage.Text) {
+override suspend fun onMessageSuspending(wireMessage: WireMessage.Text) {
     println("Message received: $wireMessage")
     
     // Add your message handling logic here, like storing the message,
@@ -162,7 +162,7 @@ override suspend fun onNewMessageSuspending(wireMessage: WireMessage.Text) {
     )
 }
 ```
-> **_Java:_**  Use `override fun onNewMessage(wireMessage: WireMessage.Text) { .. }`
+> **_Java:_**  Use `override fun onMessage(wireMessage: WireMessage.Text) { .. }`
 
 > **_Other Event Types:_** Other event types can be listened through `on[EventType]Suspending` or `on[EventType]`
 
@@ -174,7 +174,7 @@ For simplicity, you can simply forward the `AssetRemoteData` to downloadAssetSus
 actually return the asset in byte array format.
 
 ```kotlin
-override suspend fun onNewAssetSuspending(wireMessage: WireMessage.Asset) {
+override suspend fun onAssetSuspending(wireMessage: WireMessage.Asset) {
     println("Asset received: $wireMessage")
     
     // Add your asset handling logic here, like downloading the asset,
@@ -191,7 +191,7 @@ override suspend fun onNewAssetSuspending(wireMessage: WireMessage.Asset) {
     }
 }
 ```
-> **_Java:_** Use `override fun onNewAsset(wireMessage: WireMessage.Asset) { .. }`
+> **_Java:_** Use `override fun onAsset(wireMessage: WireMessage.Asset) { .. }`
 
 ## Deploy example
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -40,7 +40,7 @@ sealed interface WireMessage {
     ) : WireMessage, Item {
         @JvmRecord
         data class Mention @JvmOverloads constructor(
-            val userId: QualifiedId? = null,
+            val userId: QualifiedId,
             val offset: Int = 0,
             val length: Int = 0
         )

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
@@ -42,8 +42,8 @@ class WireAppSdkTest : KoinTest {
                 apiToken = API_TOKEN,
                 apiHost = API_HOST,
                 cryptographyStoragePassword = CRYPTOGRAPHY_STORAGE_PASSWORD,
-                object : WireEventsHandler() {
-                    override fun onNewMessage(wireMessage: WireMessage.Text) {
+                object : WireEventsHandlerDefault() {
+                    override fun onMessage(wireMessage: WireMessage.Text) {
                         println(wireMessage)
                     }
                 }
@@ -74,8 +74,8 @@ class WireAppSdkTest : KoinTest {
                 apiToken = API_TOKEN,
                 apiHost = API_HOST,
                 cryptographyStoragePassword = CRYPTOGRAPHY_STORAGE_PASSWORD,
-                object : WireEventsHandler() {
-                    override fun onNewMessage(wireMessage: WireMessage.Text) {
+                object : WireEventsHandlerDefault() {
+                    override fun onMessage(wireMessage: WireMessage.Text) {
                         println(wireMessage)
                     }
                 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -26,7 +26,7 @@ import com.wire.crypto.MlsException
 import com.wire.crypto.Welcome
 import com.wire.integrations.jvm.TestUtils
 import com.wire.integrations.jvm.TestUtils.V
-import com.wire.integrations.jvm.WireEventsHandler
+import com.wire.integrations.jvm.WireEventsHandlerSuspending
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.crypto.CryptoClient
 import com.wire.integrations.jvm.model.AppClientId
@@ -74,7 +74,7 @@ class WireEventsIntegrationTest : KoinTest {
     fun givenKoinInjectionsWhenCallingHandleEventsThenTheCorrectMethodIsCalled() {
         runBlocking {
             TestUtils.setupWireMockStubs(wireMockServer = wireMockServer)
-            val eventsHandler = object : WireEventsHandler() {}
+            val eventsHandler = object : WireEventsHandlerSuspending() {}
             TestUtils.setupSdk(eventsHandler)
 
             val eventsRouter = get<EventsRouter>()
@@ -389,8 +389,8 @@ class WireEventsIntegrationTest : KoinTest {
             }
 
         private val wireEventsHandler =
-            object : WireEventsHandler() {
-                override suspend fun onNewMessageSuspending(wireMessage: WireMessage.Text) {
+            object : WireEventsHandlerSuspending() {
+                override suspend fun onMessage(wireMessage: WireMessage.Text) {
                     // Verify
                     assertEquals(
                         MOCK_DECRYPTED_MESSAGE,

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
@@ -18,6 +18,7 @@ package com.wire.integrations.jvm.service
 
 import com.wire.crypto.MLSGroupId
 import com.wire.integrations.jvm.WireEventsHandler
+import com.wire.integrations.jvm.WireEventsHandlerSuspending
 import com.wire.integrations.jvm.model.ConversationData
 import com.wire.integrations.jvm.model.ConversationMember
 import com.wire.integrations.jvm.model.QualifiedId
@@ -43,7 +44,7 @@ class WireEventsTest : KoinTest {
     @Test
     fun givenWireEventsHandlerIsInjectedThenCallingItsMethodsSucceeds() =
         runBlocking {
-            val wireEvents = get<WireEventsHandler>()
+            val wireEvents = get<WireEventsHandler>() as WireEventsHandlerSuspending
 
             wireEvents.onConversationJoin(
                 conversation = ConversationData(
@@ -55,7 +56,7 @@ class WireEventsTest : KoinTest {
                 members = emptyList()
             )
 
-            wireEvents.onNewMessage(
+            wireEvents.onMessage(
                 wireMessage = WireMessage.Text(
                     id = UUID.randomUUID(),
                     conversationId = CONVERSATION_ID,
@@ -71,9 +72,9 @@ class WireEventsTest : KoinTest {
     @Test
     fun givenWireEventsHandlerIsInjectedThenCallingNewAssetMethodItSucceeds() =
         runBlocking {
-            val wireEvents = get<WireEventsHandler>()
+            val wireEvents = get<WireEventsHandler>() as WireEventsHandlerSuspending
 
-            wireEvents.onNewAsset(
+            wireEvents.onAsset(
                 wireMessage = WireMessage.Asset(
                     id = UUID.randomUUID(),
                     conversationId = CONVERSATION_ID,
@@ -97,9 +98,9 @@ class WireEventsTest : KoinTest {
     @Test
     fun givenWireEventsHandlerIsInjectedThenCallingNewKnockMethodItSucceeds() =
         runBlocking {
-            val wireEvents = get<WireEventsHandler>()
+            val wireEvents = get<WireEventsHandler>() as WireEventsHandlerSuspending
 
-            wireEvents.onKnockSuspending(
+            wireEvents.onKnock(
                 wireMessage = WireMessage.Knock(
                     id = UUID.randomUUID(),
                     conversationId = CONVERSATION_ID,
@@ -111,9 +112,9 @@ class WireEventsTest : KoinTest {
     @Test
     fun givenWireEventsHandlerIsInjectedThenCallingNewLocationMethodItSucceeds() =
         runBlocking {
-            val wireEvents = get<WireEventsHandler>()
+            val wireEvents = get<WireEventsHandler>() as WireEventsHandlerSuspending
 
-            wireEvents.onLocationSuspending(
+            wireEvents.onLocation(
                 wireMessage = WireMessage.Location(
                     id = UUID.randomUUID(),
                     conversationId = CONVERSATION_ID,
@@ -191,33 +192,33 @@ class WireEventsTest : KoinTest {
             """
 
         private val wireEventsHandler =
-            object : WireEventsHandler() {
-                override fun onConversationJoin(
+            object : WireEventsHandlerSuspending() {
+                override suspend fun onConversationJoin(
                     conversation: ConversationData,
                     members: List<ConversationMember>
                 ) {
                     assertEquals(CONVERSATION_ID, conversation.id)
                 }
 
-                override suspend fun onNewMessageSuspending(wireMessage: WireMessage.Text) {
+                override suspend fun onMessage(wireMessage: WireMessage.Text) {
                     assertEquals(
                         EXPECTED_NEW_MLS_MESSAGE_VALUE,
                         wireMessage.text
                     )
                 }
 
-                override suspend fun onNewAssetSuspending(wireMessage: WireMessage.Asset) {
+                override suspend fun onAsset(wireMessage: WireMessage.Asset) {
                     assertEquals(
                         EXPECTED_NEW_MLS_MESSAGE_VALUE.toString(),
                         wireMessage.name
                     )
                 }
 
-                override suspend fun onKnockSuspending(wireMessage: WireMessage.Knock) {
+                override suspend fun onKnock(wireMessage: WireMessage.Knock) {
                     assertTrue { wireMessage.hotKnock }
                 }
 
-                override suspend fun onLocationSuspending(wireMessage: WireMessage.Location) {
+                override suspend fun onLocation(wireMessage: WireMessage.Location) {
                     assertEquals(EXPECTED_LOCATION_LATITUDE, wireMessage.latitude)
                     assertEquals(EXPECTED_LOCATION_LONGITUDE, wireMessage.longitude)
                 }

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -16,7 +16,7 @@
 package com.wire.integrations.sample
 
 import com.wire.integrations.jvm.WireAppSdk
-import com.wire.integrations.jvm.WireEventsHandler
+import com.wire.integrations.jvm.WireEventsHandlerSuspending
 import com.wire.integrations.jvm.model.AssetResource
 import com.wire.integrations.jvm.model.WireMessage
 import com.wire.integrations.jvm.model.asset.AssetRetention
@@ -32,8 +32,8 @@ fun main() {
         apiToken = "myApiToken",
         apiHost = "https://nginz-https.chala.wire.link",
         cryptographyStoragePassword = "myDummyPassword",
-        object : WireEventsHandler() {
-            override suspend fun onNewMessageSuspending(wireMessage: WireMessage.Text) {
+        object : WireEventsHandlerSuspending() {
+            override suspend fun onMessage(wireMessage: WireMessage.Text) {
                 logger.info("Received Text Message : $wireMessage")
 
                 if (wireMessage.text?.contains("asset") ?: false) {
@@ -58,7 +58,7 @@ fun main() {
                 manager.sendMessageSuspending(message = message)
             }
 
-            override suspend fun onNewAssetSuspending(wireMessage: WireMessage.Asset) {
+            override suspend fun onAsset(wireMessage: WireMessage.Asset) {
                 logger.info("Received Asset Message : $wireMessage")
 
                 val message = WireMessage.Text.create(
@@ -78,7 +78,7 @@ fun main() {
                 }
             }
 
-            override suspend fun onNewCompositeSuspending(wireMessage: WireMessage.Composite) {
+            override suspend fun onComposite(wireMessage: WireMessage.Composite) {
                 logger.info("Received Composite Message : $wireMessage")
 
                 logger.info("Received Composite Items:")
@@ -87,15 +87,15 @@ fun main() {
                 }
             }
 
-            override suspend fun onNewButtonActionSuspending(wireMessage: WireMessage.ButtonAction) {
+            override suspend fun onButtonAction(wireMessage: WireMessage.ButtonAction) {
                 logger.info("Received ButtonAction Message : $wireMessage")
             }
 
-            override suspend fun onNewButtonActionConfirmationSuspending(wireMessage: WireMessage.ButtonActionConfirmation) {
+            override suspend fun onButtonActionConfirmation(wireMessage: WireMessage.ButtonActionConfirmation) {
                 logger.info("Received ButtonActionConfirmation Message : $wireMessage")
             }
 
-            override suspend fun onKnockSuspending(wireMessage: WireMessage.Knock) {
+            override suspend fun onKnock(wireMessage: WireMessage.Knock) {
                 logger.info("Received onKnockSuspending Message : $wireMessage")
 
                 val knock = WireMessage.Knock.create(
@@ -106,7 +106,7 @@ fun main() {
                 manager.sendMessageSuspending(message = knock)
             }
 
-            override suspend fun onLocationSuspending(wireMessage: WireMessage.Location) {
+            override suspend fun onLocation(wireMessage: WireMessage.Location) {
                 logger.info("Received onLocationSuspending Message : $wireMessage")
 
                 val message = WireMessage.Text.create(


### PR DESCRIPTION
* Rename methods to remove the "new"

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

EventRouter did not know if the clients used the suspending or non-suspenfing versions of functions so had to choose or call both

### Solutions

Have a common abstracts class with just 2 subclasses, the suspending and blocking versions.
EventRouter can check at runtime which version was extended

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
