### PR TITLE
feat: Handle MessageDelete and Confirmation event type #WPB-17375

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerDefault.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerDefault.kt
@@ -80,6 +80,14 @@ abstract class WireEventsHandlerDefault : WireEventsHandler() {
         logger.info("Received event: onLocation: $wireMessage")
     }
 
+    open fun onDeletedMessage(wireMessage: WireMessage.Deleted) {
+        logger.info("Received event: onDeletedMessage: $wireMessage")
+    }
+
+    open fun onReceiptConfirmation(wireMessage: WireMessage) {
+        logger.info("Received event: onReceiptConfirmation: $wireMessage")
+    }
+
     /**
      * One or more users have joined a conversation accessible by the Wire App.
      * This event is triggered when the App is already in the conversation and new users joins.

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerSuspending.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerSuspending.kt
@@ -80,6 +80,14 @@ abstract class WireEventsHandlerSuspending : WireEventsHandler() {
         logger.info("Received event: onLocation: $wireMessage")
     }
 
+    open suspend fun onDeletedMessage(wireMessage: WireMessage.Deleted) {
+        logger.info("Received event: onDeletedMessage: $wireMessage")
+    }
+
+    open suspend fun onReceiptConfirmation(wireMessage: WireMessage) {
+        logger.info("Received event: onReceiptConfirmation: $wireMessage")
+    }
+
     /**
      * One or more users have joined a conversation accessible by the Wire App.
      * This event is triggered when the App is already in the conversation and new users joins.

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -315,6 +315,99 @@ sealed interface WireMessage {
         }
     }
 
+    @JvmRecord
+    data class Deleted @JvmOverloads constructor(
+        override val id: UUID,
+        override val conversationId: QualifiedId,
+        override val sender: QualifiedId? = null,
+        val messageId: String
+    ) : WireMessage {
+        companion object {
+            /**
+             * Creates a basic Deleted message (a message was deleted).
+             *
+             * Usage from Kotlin:
+             * ```kotlin
+             * val deletedMessage = Deleted.create(conversationId, messageId)
+             * ```
+             *
+             * Usage from Java:
+             * ```java
+             * Deleted deletedMessage = Deleted.Companion.create(conversationId, messageId)
+             * ```
+             *
+             * @param conversationId The qualified ID of the conversation
+             * @param messageId The ID of the deleted message
+             * @return A new Deleted message with a random UUID
+             */
+            @JvmStatic
+            fun create(
+                conversationId: QualifiedId,
+                messageId: String
+            ): Deleted =
+                Deleted(
+                    id = UUID.randomUUID(),
+                    conversationId = conversationId,
+                    messageId = messageId
+                )
+        }
+    }
+
+    @JvmRecord
+    data class Receipt @JvmOverloads constructor(
+        override val id: UUID,
+        override val conversationId: QualifiedId,
+        override val sender: QualifiedId? = null,
+        val type: Type,
+        val messageIds: List<String>
+    ) : WireMessage {
+        enum class Type {
+            DELIVERED,
+            READ
+        }
+
+        companion object {
+            /**
+             * Creates a basic Receipt message.
+             *
+             * Usage from Kotlin:
+             * ```kotlin
+             * val receipt = Receipt.create(conversationId, messageId)
+             * ```
+             *
+             * Usage from Java:
+             * ```java
+             * Deleted deletedMessage = Deleted.Companion.create(conversationId, messageId)
+             * ```
+             *
+             * @param conversationId The qualified ID of the conversation
+             * @param messageId The ID of the deleted message
+             * @return A new Deleted message with a random UUID
+             */
+            @JvmStatic
+            fun create(
+                conversationId: QualifiedId,
+                type: Type,
+                messages: List<String> = listOf()
+            ): Receipt =
+                Receipt(
+                    id = UUID.randomUUID(),
+                    conversationId = conversationId,
+                    type = type,
+                    messageIds = messages
+                )
+        }
+    }
+
+    data object Ignored : WireMessage {
+        override val id: UUID
+            get() = throw WireException.InvalidParameter("Ignored message, no ID")
+        override val conversationId: QualifiedId
+            get() = throw WireException.InvalidParameter("Ignored message, no conversation")
+        override val sender: QualifiedId?
+            get() = throw WireException.InvalidParameter("Ignored message, no sender")
+    }
+
     data object Unknown : WireMessage {
         override val id: UUID
             get() = throw WireException.InvalidParameter("Unknown message, no ID")

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -217,6 +217,9 @@ internal class EventsRouter internal constructor(
                     wireEventsHandler.onButtonActionConfirmation(wireMessage)
                 is WireMessage.Knock -> wireEventsHandler.onKnock(wireMessage)
                 is WireMessage.Location -> wireEventsHandler.onLocation(wireMessage)
+                is WireMessage.Deleted -> wireEventsHandler.onDeletedMessage(wireMessage)
+                is WireMessage.Receipt -> wireEventsHandler.onReceiptConfirmation(wireMessage)
+                is WireMessage.Ignored -> logger.warn("Ignored event received.")
                 is WireMessage.Unknown -> logger.warn("Unknown event received.")
             }
             is WireEventsHandlerSuspending -> when (wireMessage) {
@@ -228,6 +231,9 @@ internal class EventsRouter internal constructor(
                     wireEventsHandler.onButtonActionConfirmation(wireMessage)
                 is WireMessage.Knock -> wireEventsHandler.onKnock(wireMessage)
                 is WireMessage.Location -> wireEventsHandler.onLocation(wireMessage)
+                is WireMessage.Deleted -> wireEventsHandler.onDeletedMessage(wireMessage)
+                is WireMessage.Receipt -> wireEventsHandler.onReceiptConfirmation(wireMessage)
+                is WireMessage.Ignored -> logger.warn("Ignored event received.")
                 is WireMessage.Unknown -> logger.warn("Unknown event received.")
             }
         }

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -56,6 +56,15 @@ fun main() {
                 )
 
                 manager.sendMessageSuspending(message = message)
+
+                // Sending a Read Receipt for the received message
+                val receipt = WireMessage.Receipt.create(
+                    conversationId = wireMessage.conversationId,
+                    type = WireMessage.Receipt.Type.READ,
+                    messages = listOf(wireMessage.id.toString())
+                )
+
+                manager.sendMessageSuspending(message = receipt)
             }
 
             override suspend fun onAsset(wireMessage: WireMessage.Asset) {
@@ -112,6 +121,17 @@ fun main() {
                 val message = WireMessage.Text.create(
                     conversationId = wireMessage.conversationId,
                     text = "Received Location\n\nLatitude: ${wireMessage.latitude}\n\nLongitude: ${wireMessage.longitude}\n\nName: ${wireMessage.name}\n\nZoom: ${wireMessage.zoom}"
+                )
+
+                manager.sendMessageSuspending(message = message)
+            }
+
+            override suspend fun onDeletedMessage(wireMessage: WireMessage.Deleted) {
+                logger.info("Received onDeletedMessageSuspending Message: $wireMessage")
+
+                val message = WireMessage.Text.create(
+                    conversationId = wireMessage.conversationId,
+                    text = "Deleted Messaged with ID : ${wireMessage.messageId}"
                 )
 
                 manager.sendMessageSuspending(message = message)


### PR DESCRIPTION
* Add onDeletedMessage and onReceiptConfirmation to listen for the events
* Add deserializer and serializer for both event types
* Add example of receiving/sending both new events

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no handling for receiving/sending event types of `DeletedMessage` and `Receipt`(Confirmation)

### Causes (Optional)

Not implemented yet.

### Solutions

- Add deserializer and serializer for both types
- Add event listener for both events
