### PR TITLE
feat: Add fallback for joining conversation and receiving/sending messages #WPB-17566

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -72,8 +72,9 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.insert-koin:koin-test-junit5")
+    testImplementation("io.mockk:mockk:1.14.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation("org.wiremock:wiremock:$wireMockVersion")
-    testImplementation("org.mockito:mockito-core:5.17.0")
 }
 
 java {

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
@@ -38,6 +38,7 @@ class WireAppSdk(
     private val executor = Executors.newSingleThreadExecutor()
 
     init {
+        IsolatedKoinContext.start()
         IsolatedKoinContext.setApplicationId(applicationId)
         IsolatedKoinContext.setApiHost(apiHost)
         IsolatedKoinContext.setApiToken(apiToken)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
@@ -126,14 +126,14 @@ internal class BackendClientDemo internal constructor(
         logger.info("Confirming team invite")
     }
 
+    private var tokenTimestamp: Long? = null
+
     /**
      * Login DEMO user in the backend, get access_token for further requests.
      * After the login, the token is immediately refreshed by calling /access,
      * because the new one is tied to client and has more permissions.
      * Not needed in the actual implementation, as the SDK is authenticated with the API_TOKEN
      */
-    private var tokenTimestamp: Long? = null
-
     private suspend fun loginUser(): String {
         val currentTime = System.currentTimeMillis()
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
@@ -132,40 +132,40 @@ internal class BackendClientDemo internal constructor(
      * because the new one is tied to client and has more permissions.
      * Not needed in the actual implementation, as the SDK is authenticated with the API_TOKEN
      */
-private var tokenTimestamp: Long? = null
+    private var tokenTimestamp: Long? = null
 
-private suspend fun loginUser(): String {
-    val currentTime = System.currentTimeMillis()
+    private suspend fun loginUser(): String {
+        val currentTime = System.currentTimeMillis()
 
-    // Check if token is valid (not null and not expired)
-    if (cachedAccessToken != null && tokenTimestamp != null) {
-        val timeSinceTokenIssued = currentTime - tokenTimestamp!!
-        if (timeSinceTokenIssued < TOKEN_EXPIRATION_MS) {
-            return cachedAccessToken as String
-        }
-        // Token has expired, will get a new one
-        logger.info("Access token expired, getting a new one")
-    }
-
-    val loginResponse = httpClient.post("/$API_VERSION/login") {
-        setBody(LoginRequest(DEMO_USER_EMAIL, DEMO_USER_PASSWORD))
-        contentType(ContentType.Application.Json)
-    }
-    val zuidCookie = loginResponse.setCookie()["zuid"]
-
-    val accessResponse =
-        httpClient.post("/$API_VERSION/access?client_id=$DEMO_USER_CLIENT") {
-            headers {
-                append(HttpHeaders.Cookie, "zuid=${zuidCookie!!.value}")
+        // Check if token is valid (not null and not expired)
+        if (cachedAccessToken != null && tokenTimestamp != null) {
+            val timeSinceTokenIssued = currentTime - tokenTimestamp!!
+            if (timeSinceTokenIssued < TOKEN_EXPIRATION_MS) {
+                return cachedAccessToken as String
             }
-            accept(ContentType.Application.Json)
-        }.body<LoginResponse>()
+            // Token has expired, will get a new one
+            logger.info("Access token expired, getting a new one")
+        }
 
-    cachedAccessToken = accessResponse.accessToken
-    tokenTimestamp = currentTime
+        val loginResponse = httpClient.post("/$API_VERSION/login") {
+            setBody(LoginRequest(DEMO_USER_EMAIL, DEMO_USER_PASSWORD))
+            contentType(ContentType.Application.Json)
+        }
+        val zuidCookie = loginResponse.setCookie()["zuid"]
 
-    return accessResponse.accessToken
-}
+        val accessResponse =
+            httpClient.post("/$API_VERSION/access?client_id=$DEMO_USER_CLIENT") {
+                headers {
+                    append(HttpHeaders.Cookie, "zuid=${zuidCookie!!.value}")
+                }
+                accept(ContentType.Application.Json)
+            }.body<LoginResponse>()
+
+        cachedAccessToken = accessResponse.accessToken
+        tokenTimestamp = currentTime
+
+        return accessResponse.accessToken
+    }
 
     override suspend fun updateClientWithMlsPublicKey(
         appClientId: AppClientId,

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/config/Modules.kt
@@ -33,6 +33,7 @@ import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamSqlLiteStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
 import com.wire.integrations.jvm.service.EventsRouter
+import com.wire.integrations.jvm.service.MlsFallbackStrategy
 import com.wire.integrations.jvm.service.WireApplicationManager
 import com.wire.integrations.jvm.service.WireTeamEventsListener
 import com.wire.integrations.jvm.utils.KtxSerializer
@@ -71,7 +72,8 @@ val sdkModule =
         single<AppStorage> { AppSqlLiteStorage(AppsSdkDatabase(get())) }
         single<BackendClient> { BackendClientDemo(get()) }
         single<MlsTransport> { MlsTransportImpl(get()) }
-        single { EventsRouter(get(), get(), get(), get(), get()) }
+        single<MlsFallbackStrategy> { MlsFallbackStrategy(get(), get()) }
+        single { EventsRouter(get(), get(), get(), get(), get(), get()) }
         single<HttpClient> {
             createHttpClient(IsolatedKoinContext.getApiHost())
         }
@@ -81,7 +83,7 @@ val sdkModule =
             }
         }
         single { WireTeamEventsListener(get(), get()) }
-        single { WireApplicationManager(get(), get(), get(), get()) }
+        single { WireApplicationManager(get(), get(), get(), get(), get()) }
     }
 
 @OptIn(ExperimentalLogbookKtorApi::class)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -157,10 +157,6 @@ internal class CoreCryptoClient private constructor(
         }
     }
 
-    override suspend fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean {
-        return coreCrypto.transaction { it.conversationExists(mlsGroupId) }
-    }
-
     override suspend fun joinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId {
         return coreCrypto.transaction { it.joinByExternalCommit(groupInfo).id }
     }
@@ -192,6 +188,16 @@ internal class CoreCryptoClient private constructor(
         val packageCount = coreCrypto.transaction { it.validKeyPackageCount(ciphersuite) }
         return packageCount < DEFAULT_KEYPACKAGE_COUNT / 2u
     }
+
+    override suspend fun conversationExists(mlsGroupId: MLSGroupId): Boolean =
+        coreCrypto.transaction {
+            it.conversationExists(mlsGroupId)
+        }
+
+    override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong =
+        coreCrypto.transaction {
+            it.conversationEpoch(mlsGroupId)
+        }
 
     override fun close() {
         runBlocking { coreCrypto.close() }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -196,6 +196,7 @@ internal class CoreCryptoClient private constructor(
 
     override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong =
         coreCrypto.transaction {
+            println("RECEIVING CV_E - CCC -> ?")
             it.conversationEpoch(mlsGroupId)
         }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -196,7 +196,6 @@ internal class CoreCryptoClient private constructor(
 
     override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong =
         coreCrypto.transaction {
-            println("RECEIVING CV_E - CCC -> ?")
             it.conversationEpoch(mlsGroupId)
         }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
@@ -42,11 +42,8 @@ internal interface CryptoClient : AutoCloseable {
         packageCount: UInt = DEFAULT_KEYPACKAGE_COUNT
     ): List<MLSKeyPackage>
 
-    suspend fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean
-
     /**
      * Create a request to join an MLS conversation.
-     * Needs to be followed by a call to markMlsConversationAsJoined() to complete the process.
      */
     suspend fun joinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId
 
@@ -71,6 +68,10 @@ internal interface CryptoClient : AutoCloseable {
     suspend fun processWelcomeMessage(welcome: Welcome): MLSGroupId
 
     suspend fun hasTooFewKeyPackageCount(): Boolean
+
+    suspend fun conversationExists(mlsGroupId: MLSGroupId): Boolean
+
+    suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong
 
     companion object {
         const val DEFAULT_KEYPACKAGE_COUNT = 100u

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireException.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireException.kt
@@ -16,6 +16,8 @@
 
 package com.wire.integrations.jvm.exception
 
+import io.ktor.http.HttpStatusCode
+
 /**
  * Class containing all Wire Error Exceptions that are going to be thrown to the developer
  * who uses the SDK.
@@ -54,8 +56,11 @@ sealed class WireException @JvmOverloads constructor(
     /**
      * Client Error
      */
-    class ClientError(message: String? = null, throwable: Throwable? = null) :
-        WireException(message ?: throwable?.localizedMessage, throwable)
+    data class ClientError(
+        override val message: String? = null,
+        val throwable: Throwable? = null,
+        val status: HttpStatusCode
+    ) : WireException(message ?: throwable?.localizedMessage, throwable)
 
     /**
      * Internal Error

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireExceptionMapper.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireExceptionMapper.kt
@@ -25,7 +25,10 @@ fun Exception.mapToWireException() =
     when (this) {
         is WireException -> this
         is InterruptedException -> WireException.InternalSystemError(throwable = this)
-        is ClientRequestException -> WireException.ClientError(throwable = this)
+        is ClientRequestException -> WireException.ClientError(
+            throwable = this,
+            status = this.response.status
+        )
         else -> WireException.UnknownError(throwable = this)
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -16,7 +16,6 @@
 
 package com.wire.integrations.jvm.model
 
-import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.exception.WireException
 import java.util.UUID
 
@@ -69,7 +68,10 @@ sealed interface WireMessage {
                 return Text(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     text = text,
                     mentions = mentions,
                     expiresAfterMillis = expiresAfterMillis
@@ -172,7 +174,10 @@ sealed interface WireMessage {
                 return Composite(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     items = listOf(textItem) + buttonList
                 )
             }
@@ -249,7 +254,10 @@ sealed interface WireMessage {
                 return Knock(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     hotKnock = hotKnock,
                     expiresAfterMillis = expiresAfterMillis
                 )
@@ -293,7 +301,10 @@ sealed interface WireMessage {
                 return Location(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     latitude = latitude,
                     longitude = longitude,
                     name = name,
@@ -327,7 +338,10 @@ sealed interface WireMessage {
                 Deleted(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     messageId = messageId
                 )
         }
@@ -364,7 +378,10 @@ sealed interface WireMessage {
                 Receipt(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     type = type,
                     messageIds = messages
                 )
@@ -400,7 +417,10 @@ sealed interface WireMessage {
                 return TextEdited(
                     id = originalMessageId,
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     newContent = text,
                     newMentions = mentions
                 )

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -39,15 +39,16 @@ import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
 import com.wire.integrations.protobuf.messages.Messages.GenericMessage
 import io.ktor.client.plugins.ResponseException
-import org.slf4j.LoggerFactory
 import java.util.Base64
+import org.slf4j.LoggerFactory
 
 internal class EventsRouter internal constructor(
     private val teamStorage: TeamStorage,
     private val conversationStorage: ConversationStorage,
     private val backendClient: BackendClient,
     private val wireEventsHandler: WireEventsHandler,
-    private val cryptoClient: CryptoClient
+    private val cryptoClient: CryptoClient,
+    private val mlsFallbackStrategy: MlsFallbackStrategy
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -129,44 +130,10 @@ internal class EventsRouter internal constructor(
                         event = event
                     )
 
-                    val conversation = backendClient.getConversation(event.qualifiedConversation)
-                    val conversationData =
-                        ConversationData(
-                            id = event.qualifiedConversation,
-                            name = conversation.name,
-                            mlsGroupId = groupId,
-                            teamId = conversation.teamId?.let { TeamId(it) }
-                        )
-                    val members = conversation.members.others.map {
-                        ConversationMember(
-                            userId = it.id,
-                            role = it.conversationRole
-                        )
-                    }
-                    logger.debug("Conversation data: $conversationData")
-                    logger.debug("Conversation members: $members")
-
-                    // Saves the conversation in the local database, used later to decrypt messages
-                    conversationStorage.save(conversationData)
-                    conversationStorage.saveMembers(event.qualifiedConversation, members)
-
-                    if (cryptoClient.hasTooFewKeyPackageCount()) {
-                        backendClient.uploadMlsKeyPackages(
-                            appClientId = cryptoClient.getAppClientId(),
-                            mlsKeyPackages = cryptoClient.mlsGenerateKeyPackages().map { it.value }
-                        )
-                    }
-
-                    when (wireEventsHandler) {
-                        is WireEventsHandlerDefault -> wireEventsHandler.onConversationJoin(
-                            conversation = conversationData,
-                            members = members
-                        )
-                        is WireEventsHandlerSuspending -> wireEventsHandler.onConversationJoin(
-                            conversation = conversationData,
-                            members = members
-                        )
-                    }
+                    handleJoiningConversation(
+                        qualifiedConversation = event.qualifiedConversation,
+                        groupId = groupId
+                    )
                 }
 
                 is EventContentDTO.Conversation.NewMLSMessageDTO -> {
@@ -194,6 +161,56 @@ internal class EventsRouter internal constructor(
                 }
             }
         }
+    }
+
+    private suspend fun handleJoiningConversation(
+        qualifiedConversation: QualifiedId,
+        groupId: MLSGroupId?
+    ): MLSGroupId {
+        val conversation = backendClient.getConversation(qualifiedConversation)
+        val mlsGroupId = groupId ?: MLSGroupId(Base64.getDecoder().decode(conversation.groupId))
+
+        val conversationData =
+            ConversationData(
+                id = qualifiedConversation,
+                name = conversation.name,
+                mlsGroupId = mlsGroupId,
+                teamId = conversation.teamId?.let { TeamId(it) }
+            )
+        val members = conversation.members.others.map {
+            ConversationMember(
+                userId = it.id,
+                role = it.conversationRole
+            )
+        }
+        logger.debug("Conversation data: $conversationData")
+        logger.debug("Conversation members: $members")
+
+        // Saves the conversation in the local database, used later to decrypt messages
+        conversationStorage.save(conversationData)
+        conversationStorage.saveMembers(qualifiedConversation, members)
+
+        if (cryptoClient.hasTooFewKeyPackageCount()) {
+            backendClient.uploadMlsKeyPackages(
+                appClientId = cryptoClient.getAppClientId(),
+                mlsKeyPackages = cryptoClient.mlsGenerateKeyPackages().map { it.value }
+            )
+        }
+
+        groupId?.run {
+            when (wireEventsHandler) {
+                is WireEventsHandlerDefault -> wireEventsHandler.onConversationJoin(
+                    conversation = conversationData,
+                    members = members
+                )
+                is WireEventsHandlerSuspending -> wireEventsHandler.onConversationJoin(
+                    conversation = conversationData,
+                    members = members
+                )
+            }
+        }
+
+        return mlsGroupId
     }
 
     /**
@@ -274,18 +291,30 @@ internal class EventsRouter internal constructor(
     /**
      * Fetches the group ID of the conversation in the local database.
      */
-    private fun fetchGroupIdFromConversation(conversationId: QualifiedId): MLSGroupId {
+    private suspend fun fetchGroupIdFromConversation(conversationId: QualifiedId): MLSGroupId {
         logger.debug(
             "Searching for group ID of conversation: {}:{}",
             conversationId.id,
             conversationId.domain
         )
 
-        val storedConversation = conversationStorage.getById(conversationId)
-        logger.debug("Found conversation: $storedConversation")
-        return storedConversation?.mlsGroupId ?: throw WireException.EntityNotFound(
-            "No local data for conversation $conversationId"
+        val conversation = conversationStorage.getById(conversationId)
+        var mlsGroupId = conversation?.mlsGroupId
+
+        if (mlsGroupId == null) {
+            mlsGroupId = handleJoiningConversation(
+                qualifiedConversation = conversationId,
+                groupId = null
+            )
+        }
+
+        mlsFallbackStrategy.verifyConversationOutOfSync(
+            mlsGroupId = mlsGroupId,
+            conversationId = conversationId
         )
+
+        logger.debug("Returning mlsGroupId: $mlsGroupId")
+        return mlsGroupId
     }
 
     private suspend fun newTeamInvite(teamId: TeamId) {

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -137,17 +137,20 @@ internal class EventsRouter internal constructor(
                 }
 
                 is EventContentDTO.Conversation.NewMLSMessageDTO -> {
+                    println("RECEIVING CV_E - NMLSMDTO - 1")
                     val groupId = fetchGroupIdFromConversation(event.qualifiedConversation)
-
+                    println("RECEIVING CV_E - NMLSMDTO - 2")
                     val message = cryptoClient.decryptMls(
                         mlsGroupId = groupId,
                         encryptedMessage = event.message
                     )
+                    println("RECEIVING CV_E - NMLSMDTO - 3")
                     logger.debug("Decryption successful")
                     if (message == null) {
                         logger.debug("Decryption success but no message, probably epoch update")
                         return
                     }
+                    println("RECEIVING CV_E - NMLSMDTO - 4")
 
                     forwardMessage(
                         message = message,
@@ -222,7 +225,9 @@ internal class EventsRouter internal constructor(
         conversationId: QualifiedId,
         sender: QualifiedId
     ) {
+        println("RECEIVING CV_E - FRWD - 1")
         val genericMessage = GenericMessage.parseFrom(message)
+        println("RECEIVING CV_E - FRWD - 2")
         val wireMessage = ProtobufDeserializer.processGenericMessage(
             genericMessage = genericMessage,
             conversationId = conversationId,
@@ -282,7 +287,7 @@ internal class EventsRouter internal constructor(
                     backendClient.getConversationGroupInfo(event.qualifiedConversation)
                 cryptoClient.joinMlsConversationRequest(GroupInfo(groupInfo))
             } else {
-                logger.error("Cannot process welcome", ex)
+                logger.error("Cannot process welcome -- ${ex.exception}", ex)
                 throw WireException.CryptographicSystemError("Cannot process welcome")
             }
         }
@@ -307,12 +312,12 @@ internal class EventsRouter internal constructor(
                 groupId = null
             )
         }
-
+        println("RECEIVING CV_E - ER - 1")
         mlsFallbackStrategy.verifyConversationOutOfSync(
             mlsGroupId = mlsGroupId,
             conversationId = conversationId
         )
-
+        println("RECEIVING CV_E - ER - 2")
         logger.debug("Returning mlsGroupId: $mlsGroupId")
         return mlsGroupId
     }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -52,7 +52,7 @@ internal class EventsRouter internal constructor(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "NestedBlockDepth", "CyclomaticComplexMethod")
     internal suspend fun route(eventResponse: EventResponse) {
         logger.debug("Event received: {}", eventResponse)
         eventResponse.payload?.forEach { event ->

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.service
+
+import com.wire.crypto.GroupInfo
+import com.wire.crypto.MLSGroupId
+import com.wire.integrations.jvm.client.BackendClient
+import com.wire.integrations.jvm.crypto.CryptoClient
+import com.wire.integrations.jvm.model.QualifiedId
+
+class MlsFallbackStrategy internal constructor(
+    private val backendClient: BackendClient,
+    private val cryptoClient: CryptoClient
+) {
+    /**
+     * Verifies if a conversation is out of sync and re-syncs (re-joining or updating the epoch)
+     *
+     * If current CoreCrypto client is not a member of the given conversation or
+     * current epoch value is different from remote epoch value, then a join by External Commit
+     * is sent to CoreCrypto.
+     *
+     * @param mlsGroupId [MLSGroupId] Conversation GroupId
+     * @param conversationId [QualifiedId] Conversation QualifiedId
+     */
+    suspend fun verifyConversationOutOfSync(
+        mlsGroupId: MLSGroupId,
+        conversationId: QualifiedId
+    ) {
+        val conversationExists = cryptoClient.conversationExists(mlsGroupId = mlsGroupId)
+        val fetchedConversation = backendClient.getConversation(conversationId = conversationId)
+        val currentEpoch = cryptoClient.conversationEpoch(mlsGroupId = mlsGroupId)
+
+        if (!conversationExists || currentEpoch.toLong() < fetchedConversation.epoch) {
+            val groupInfo = backendClient.getConversationGroupInfo(
+                conversationId = conversationId
+            )
+            cryptoClient.joinMlsConversationRequest(
+                groupInfo = GroupInfo(value = groupInfo)
+            )
+        }
+    }
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
@@ -16,7 +16,6 @@
 package com.wire.integrations.jvm.service
 
 import com.wire.integrations.jvm.client.BackendClient
-import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.crypto.CryptoClient
 import com.wire.integrations.jvm.exception.WireException
 import com.wire.integrations.jvm.model.AssetResource
@@ -267,7 +266,10 @@ class WireApplicationManager internal constructor(
         val assetMessage = WireMessage.Asset(
             id = UUID.randomUUID(),
             conversationId = conversationId,
-            sender = IsolatedKoinContext.getApplicationQualifiedId(),
+            sender = QualifiedId(
+                id = UUID.randomUUID(),
+                domain = UUID.randomUUID().toString()
+            ),
             sizeInBytes = encryptedAsset.size.toLong(),
             mimeType = mimeType,
             remoteData = AssetMetadata.RemoteData(

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
@@ -37,6 +37,7 @@ import com.wire.integrations.jvm.persistence.TeamStorage
 import com.wire.integrations.jvm.utils.AESDecrypt
 import com.wire.integrations.jvm.utils.AESEncrypt
 import com.wire.integrations.jvm.utils.MAX_DATA_SIZE
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 
@@ -49,7 +50,8 @@ class WireApplicationManager internal constructor(
     private val teamStorage: TeamStorage,
     private val conversationStorage: ConversationStorage,
     private val backendClient: BackendClient,
-    private val cryptoClient: CryptoClient
+    private val cryptoClient: CryptoClient,
+    private val mlsFallbackStrategy: MlsFallbackStrategy
 ) {
     fun getStoredTeams(): List<TeamId> = teamStorage.getAll()
 
@@ -132,12 +134,26 @@ class WireApplicationManager internal constructor(
     suspend fun sendMessageSuspending(message: WireMessage): UUID {
         val conversation = conversationStorage.getById(conversationId = message.conversationId)
         conversation?.mlsGroupId?.let { mlsGroupId ->
-            backendClient.sendMessage(
-                mlsMessage = cryptoClient.encryptMls(
-                    mlsGroupId = mlsGroupId,
-                    message = ProtobufSerializer.toGenericMessageByteArray(wireMessage = message)
+            try {
+                backendClient.sendMessage(
+                    mlsMessage = cryptoClient.encryptMls(
+                        mlsGroupId = mlsGroupId,
+                        message = ProtobufSerializer
+                            .toGenericMessageByteArray(
+                                wireMessage = message
+                            )
+                    )
                 )
-            )
+            } catch (exception: WireException.ClientError) {
+                // TODO(WireException): Properly handle mls-stale-message exception type
+                if (exception.status == HttpStatusCode.Conflict) {
+                    mlsFallbackStrategy.verifyConversationOutOfSync(
+                        mlsGroupId = mlsGroupId,
+                        conversationId = message.conversationId
+                    )
+                    // TODO(FallbackStrategy): Should we try sending the message again?
+                }
+            }
         } ?: throw WireException.EntityNotFound("Couldn't find Conversation MLS Group ID")
         return message.id
     }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
@@ -24,15 +24,10 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.koin.core.Koin
-import org.koin.test.KoinTest
 import java.util.UUID
 import kotlin.test.assertEquals
 
-class WireAppSdkTest : KoinTest {
-    // Override the Koin instance as we use an isolated context
-    override fun getKoin(): Koin = IsolatedKoinContext.koinApp.koin
-
+class WireAppSdkTest {
     @Test
     fun koinModulesLoadCorrectly() {
         TestUtils.setupWireMockStubs(wireMockServer = wireMockServer)
@@ -96,12 +91,14 @@ class WireAppSdkTest : KoinTest {
         @BeforeAll
         fun before() {
             wireMockServer.start()
+            IsolatedKoinContext.start()
         }
 
         @JvmStatic
         @AfterAll
         fun after() {
             wireMockServer.stop()
+            IsolatedKoinContext.stop()
         }
     }
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
@@ -81,7 +81,7 @@ class CoreCryptoClientTest : KoinTest {
                 mlsTransport = testMlsTransport
             )
             val groupIdGenerated: MLSGroupId = mlsClient.joinMlsConversationRequest(groupInfo)
-            assertTrue { mlsClient.mlsConversationExists(groupIdGenerated) }
+            assertTrue { mlsClient.conversationExists(groupIdGenerated) }
 
             // Encrypt a message for the joined conversation
             val plainMessage = UUID.randomUUID().toString()
@@ -126,9 +126,9 @@ class CoreCryptoClientTest : KoinTest {
             // Create a new conversation with Bob, then add Alice to it
             val groupId = "JfflcPtUivbg+1U3Iyrzsh5D2ui/OGS5Rvf52ipH5KY=".toGroupId()
             bobClient.createConversation(groupId)
-            assertTrue { bobClient.mlsConversationExists(groupId) }
+            assertTrue { bobClient.conversationExists(groupId) }
             val keyPackages: List<MLSKeyPackage> = aliceClient.mlsGenerateKeyPackages(1u)
-            assertFalse { aliceClient.mlsConversationExists(groupId) }
+            assertFalse { aliceClient.conversationExists(groupId) }
 
             assertNotEquals(bobClient.mlsGetPublicKey(), aliceClient.mlsGetPublicKey())
             bobClient.addMemberToMlsConversation(groupId, keyPackages)
@@ -136,7 +136,7 @@ class CoreCryptoClientTest : KoinTest {
             // Alice accepts joining the conversation
             val welcomeMessage = testMlsTransport.getLastWelcome()
             aliceClient.processWelcomeMessage(welcomeMessage)
-            assert(aliceClient.mlsConversationExists(groupId))
+            assert(aliceClient.conversationExists(groupId))
 
             // Alice encrypts a message for the joined conversation
             val plainMessage = "random_message" // UUID.randomUUID().toString()

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
@@ -18,8 +18,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.koin.core.Koin
-import org.koin.test.KoinTest
 import java.io.FileInputStream
 import java.io.InputStream
 import java.util.Base64
@@ -29,10 +27,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.AfterAll
 
-class CoreCryptoClientTest : KoinTest {
-    override fun getKoin(): Koin = IsolatedKoinContext.koinApp.koin
-
+class CoreCryptoClientTest {
     private val testMlsTransport = MlsTransportLastWelcome()
 
     @Test
@@ -139,7 +136,7 @@ class CoreCryptoClientTest : KoinTest {
             assert(aliceClient.conversationExists(groupId))
 
             // Alice encrypts a message for the joined conversation
-            val plainMessage = "random_message" // UUID.randomUUID().toString()
+            val plainMessage = "random_message"
             val wireTextMessage = WireMessage.Text.create(
                 conversationId = CONVERSATION_ID,
                 text = plainMessage
@@ -186,6 +183,7 @@ class CoreCryptoClientTest : KoinTest {
         @BeforeAll
         fun before() {
             // Testing that full UTF-8 is accepted on storage password
+            IsolatedKoinContext.start()
             IsolatedKoinContext.setCryptographyStoragePassword("banana🍌")
         }
 
@@ -193,5 +191,11 @@ class CoreCryptoClientTest : KoinTest {
             id = UUID.randomUUID(),
             domain = UUID.randomUUID().toString()
         )
+
+        @JvmStatic
+        @AfterAll
+        fun after() {
+            IsolatedKoinContext.stop()
+        }
     }
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.service
+
+import com.wire.crypto.GroupInfo
+import com.wire.crypto.MLSGroupId
+import com.wire.integrations.jvm.client.BackendClientDemo
+import com.wire.integrations.jvm.crypto.CryptoClient
+import com.wire.integrations.jvm.model.QualifiedId
+import com.wire.integrations.jvm.model.TeamId
+import com.wire.integrations.jvm.model.http.conversation.ConversationMembers
+import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.util.UUID
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class MlsFallbackStrategyTest {
+    @Test
+    fun whenConversationDoesNotExistLocally_thenRejoinConversation() =
+        runTest {
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(mlsGroupId = MLS_GROUP_ID) } returns false
+                coEvery { conversationEpoch(mlsGroupId = MLS_GROUP_ID) } returns 0UL
+                coEvery {
+                    joinMlsConversationRequest(groupInfo = GroupInfo(MLS_GROUP_ID.value))
+                } returns MLS_GROUP_ID
+            }
+
+            val backendClient = mockk<BackendClientDemo> {
+                coEvery {
+                    getConversation(conversationId = CONVERSATION_ID)
+                } returns CONVERSATION_RESPONSE
+                coEvery {
+                    getConversationGroupInfo(conversationId = CONVERSATION_ID)
+                } returns MLS_GROUP_ID.value
+            }
+
+            val fallbackStrategy = MlsFallbackStrategy(
+                backendClient = backendClient,
+                cryptoClient = cryptoClient
+            )
+
+            fallbackStrategy.verifyConversationOutOfSync(
+                mlsGroupId = MLS_GROUP_ID,
+                conversationId = CONVERSATION_ID
+            )
+
+            coVerify(exactly = 1) {
+                cryptoClient.joinMlsConversationRequest(
+                    groupInfo = GroupInfo(value = MLS_GROUP_ID.value)
+                )
+            }
+        }
+
+    @Test
+    fun whenConversationEpochIsOutOfSync_thenRejoinConversation() =
+        runTest {
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(mlsGroupId = MLS_GROUP_ID) } returns true
+                coEvery { conversationEpoch(mlsGroupId = MLS_GROUP_ID) } returns 1UL
+                coEvery {
+                    joinMlsConversationRequest(groupInfo = GroupInfo(MLS_GROUP_ID.value))
+                } returns MLS_GROUP_ID
+            }
+
+            val backendClient = mockk<BackendClientDemo> {
+                coEvery {
+                    getConversation(conversationId = CONVERSATION_ID)
+                } returns CONVERSATION_RESPONSE.copy(epoch = 2L)
+                coEvery {
+                    getConversationGroupInfo(conversationId = CONVERSATION_ID)
+                } returns MLS_GROUP_ID.value
+            }
+
+            val fallbackStrategy = MlsFallbackStrategy(
+                backendClient = backendClient,
+                cryptoClient = cryptoClient
+            )
+
+            fallbackStrategy.verifyConversationOutOfSync(
+                mlsGroupId = MLS_GROUP_ID,
+                conversationId = CONVERSATION_ID
+            )
+
+            coVerify(exactly = 1) {
+                cryptoClient.joinMlsConversationRequest(
+                    groupInfo = GroupInfo(value = MLS_GROUP_ID.value)
+                )
+            }
+        }
+
+    @Test
+    fun whenConversationIsSynced_thenLogicIsIgnored() =
+        runTest {
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(mlsGroupId = MLS_GROUP_ID) } returns true
+                coEvery { conversationEpoch(mlsGroupId = MLS_GROUP_ID) } returns 1UL
+                coEvery {
+                    joinMlsConversationRequest(groupInfo = GroupInfo(MLS_GROUP_ID.value))
+                } returns MLS_GROUP_ID
+            }
+
+            val backendClient = mockk<BackendClientDemo> {
+                coEvery {
+                    getConversation(conversationId = CONVERSATION_ID)
+                } returns CONVERSATION_RESPONSE.copy(epoch = 1L)
+                coEvery {
+                    getConversationGroupInfo(conversationId = CONVERSATION_ID)
+                } returns MLS_GROUP_ID.value
+            }
+
+            val fallbackStrategy = MlsFallbackStrategy(
+                backendClient = backendClient,
+                cryptoClient = cryptoClient
+            )
+
+            fallbackStrategy.verifyConversationOutOfSync(
+                mlsGroupId = MLS_GROUP_ID,
+                conversationId = CONVERSATION_ID
+            )
+
+            coVerify(exactly = 0) {
+                cryptoClient.joinMlsConversationRequest(
+                    groupInfo = GroupInfo(value = MLS_GROUP_ID.value)
+                )
+                backendClient.getConversationGroupInfo(
+                    conversationId = CONVERSATION_ID
+                )
+            }
+        }
+
+    companion object {
+        private val CONVERSATION_ID =
+            QualifiedId(
+                id = UUID.randomUUID(),
+                domain = "wire.com"
+            )
+        private val TEAM_ID = TeamId(UUID.randomUUID())
+        private val MLS_GROUP_ID = MLSGroupId(ByteArray(32) { 1 })
+        private val CONVERSATION_RESPONSE = ConversationResponse(
+            id = CONVERSATION_ID,
+            teamId = TEAM_ID.value,
+            groupId = MLS_GROUP_ID.toString(),
+            name = "Random Conversation",
+            epoch = 0L,
+            members = ConversationMembers(others = emptyList())
+        )
+    }
+}

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -213,6 +213,8 @@ class WireEventsIntegrationTest : KoinTest {
                 eventResponse = NEW_WELCOME_EVENT
             )
 
+            // VERIFICAR OS MOCK DO CC + CONVERSATION EXISTE/EPOCH
+
             val encryptedBase64Message = Base64
                 .getEncoder()
                 .encodeToString(
@@ -329,6 +331,8 @@ class WireEventsIntegrationTest : KoinTest {
         // Replace the real crypto client with a mock one for MLS decryption
         private fun mockCryptoClient() =
             object : CryptoClient {
+                val conversationExist = mutableSetOf<MLSGroupId>()
+
                 override suspend fun decryptMls(
                     mlsGroupId: MLSGroupId,
                     encryptedMessage: String
@@ -366,10 +370,6 @@ class WireEventsIntegrationTest : KoinTest {
                     TODO("Not yet implemented")
                 }
 
-                override suspend fun mlsConversationExists(mlsGroupId: MLSGroupId): Boolean {
-                    TODO("Not yet implemented")
-                }
-
                 override suspend fun hasTooFewKeyPackageCount(): Boolean = false
 
                 override fun close() {
@@ -386,6 +386,13 @@ class WireEventsIntegrationTest : KoinTest {
                 ) {
                     TODO("Not yet implemented")
                 }
+
+                override suspend fun conversationExists(mlsGroupId: MLSGroupId): Boolean {
+                    val wasConversationAdded = conversationExist.add(mlsGroupId)
+                    return !wasConversationAdded
+                }
+
+                override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong = 1UL
             }
 
         private val wireEventsHandler =

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -24,6 +24,7 @@ import com.wire.crypto.MLSGroupId
 import com.wire.crypto.MLSKeyPackage
 import com.wire.crypto.MlsException
 import com.wire.crypto.Welcome
+import com.wire.crypto.toByteArray
 import com.wire.integrations.jvm.TestUtils
 import com.wire.integrations.jvm.TestUtils.V
 import com.wire.integrations.jvm.WireEventsHandlerSuspending
@@ -51,10 +52,7 @@ import kotlinx.datetime.Instant
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.koin.core.Koin
 import org.koin.dsl.module
-import org.koin.test.KoinTest
-import org.koin.test.get
 import java.util.Base64
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -66,10 +64,7 @@ import kotlin.test.assertTrue
  * It mocks the CryptoClient and uses WireMock to send real http call to a temporary server.
  * All the other components are real and use the real Koin context.
  */
-class WireEventsIntegrationTest : KoinTest {
-    // Override the Koin instance as we use an isolated context
-    override fun getKoin(): Koin = IsolatedKoinContext.koinApp.koin
-
+class WireEventsIntegrationTest {
     @Test
     fun givenKoinInjectionsWhenCallingHandleEventsThenTheCorrectMethodIsCalled() {
         runBlocking {
@@ -77,7 +72,7 @@ class WireEventsIntegrationTest : KoinTest {
             val eventsHandler = object : WireEventsHandlerSuspending() {}
             TestUtils.setupSdk(eventsHandler)
 
-            val eventsRouter = get<EventsRouter>()
+            val eventsRouter = IsolatedKoinContext.koinApp.koin.get<EventsRouter>()
             eventsRouter.route(
                 eventResponse = NEW_TEAM_INVITE_EVENT
             )
@@ -85,8 +80,7 @@ class WireEventsIntegrationTest : KoinTest {
                 eventResponse = NEW_CONVERSATION_EVENT
             )
 
-            val teamStorage = get<TeamStorage>()
-            println("SIZE == ${teamStorage.getAll().size}")
+            val teamStorage = IsolatedKoinContext.koinApp.koin.get<TeamStorage>()
             assertTrue { teamStorage.getAll().size == 1 }
         }
     }
@@ -99,17 +93,27 @@ class WireEventsIntegrationTest : KoinTest {
         // Create SDK with our custom handler
         TestUtils.setupSdk(wireEventsHandler)
 
+        // Load Koin Modules
+        IsolatedKoinContext.koin.loadModules(
+            listOf(
+                module {
+                    single<CryptoClient> { mockCryptoClient() }
+                }
+            )
+        )
+
         val conversationId =
             QualifiedId(
                 id = UUID.randomUUID(),
                 domain = "wire.com"
             )
+
         // Execute
-        val conversationStorage = get<ConversationStorage>()
+        val conversationStorage = IsolatedKoinContext.koinApp.koin.get<ConversationStorage>()
         val conversationPrevious = conversationStorage.getById(conversationId)
         assertNull(conversationPrevious)
 
-        val eventsRouter = get<EventsRouter>()
+        val eventsRouter = IsolatedKoinContext.koinApp.koin.get<EventsRouter>()
 
         runBlocking {
             eventsRouter.route(
@@ -198,12 +202,21 @@ class WireEventsIntegrationTest : KoinTest {
         // Create SDK with our custom handler
         TestUtils.setupSdk(wireEventsHandler)
 
+        // Load Koin Modules
+        IsolatedKoinContext.koin.loadModules(
+            listOf(
+                module {
+                    single<CryptoClient> { mockCryptoClient() }
+                }
+            )
+        )
+
         // Execute
-        val conversationStorage = get<ConversationStorage>()
+        val conversationStorage = IsolatedKoinContext.koinApp.koin.get<ConversationStorage>()
         val conversationPrevious = conversationStorage.getById(CONVERSATION_ID)
         assertNull(conversationPrevious)
 
-        val eventsRouter = get<EventsRouter>()
+        val eventsRouter = IsolatedKoinContext.koinApp.koin.get<EventsRouter>()
 
         runBlocking {
             eventsRouter.route(
@@ -212,8 +225,6 @@ class WireEventsIntegrationTest : KoinTest {
             eventsRouter.route(
                 eventResponse = NEW_WELCOME_EVENT
             )
-
-            // VERIFICAR OS MOCK DO CC + CONVERSATION EXISTE/EPOCH
 
             val encryptedBase64Message = Base64
                 .getEncoder()
@@ -239,6 +250,7 @@ class WireEventsIntegrationTest : KoinTest {
         val conversation = conversationStorage.getById(CONVERSATION_ID)
         assertEquals(conversation?.id, CONVERSATION_ID)
         assertEquals(conversation?.teamId, TEAM_ID)
+
         val conversationMember = conversationStorage.getMembersByConversationId(CONVERSATION_ID)
         assertEquals(1, conversationMember.size)
     }
@@ -257,7 +269,7 @@ class WireEventsIntegrationTest : KoinTest {
                 domain = "wire.com"
             )
         private val TEAM_ID = TeamId(UUID.randomUUID())
-        private val MLS_GROUP_ID = MLSGroupId(ByteArray(32) { 1 })
+        private val MLS_GROUP_ID = MLSGroupId(UUID.randomUUID().toString().toByteArray())
 
         private val NEW_TEAM_INVITE_EVENT =
             EventResponse(
@@ -392,7 +404,7 @@ class WireEventsIntegrationTest : KoinTest {
                     return !wasConversationAdded
                 }
 
-                override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong = 1UL
+                override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong = 0UL
             }
 
         private val wireEventsHandler =
@@ -409,6 +421,8 @@ class WireEventsIntegrationTest : KoinTest {
         @JvmStatic
         @BeforeAll
         fun before() {
+            IsolatedKoinContext.start()
+
             wireMockServer.start()
 
             // Mock conversation fetching
@@ -453,18 +467,13 @@ class WireEventsIntegrationTest : KoinTest {
                             .withBody(ByteArray(128) { 1 })
                     )
             )
-
-            // Load the full IsolatedKoinContext, then override just the crypto client
-            val module = module {
-                single<CryptoClient> { mockCryptoClient() }
-            }
-            IsolatedKoinContext.koinApp.koin.loadModules(listOf(module))
         }
 
         @JvmStatic
         @AfterAll
         fun after() {
             wireMockServer.stop()
+            IsolatedKoinContext.stop()
         }
     }
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
@@ -235,7 +235,9 @@ class WireEventsTest : KoinTest {
                 modules(
                     module {
                         single<WireEventsHandler> { wireEventsHandler }
-                        single<EventsRouter> { EventsRouter(get(), get(), get(), get(), get()) }
+                        single<EventsRouter> {
+                            EventsRouter(get(), get(), get(), get(), get(), get())
+                        }
                     }
                 )
             }


### PR DESCRIPTION
* Add conversationExists and conversationEpoch to CryptoClient
* Change ClientError exception to be a data class and include HttpStatusCode
* Add MlsFallbackStrategy to handle when an CoreCrypto external commit must be sent and its tests
* When sending a message check for fallback strategy if it needs to send an external commit
* Move handling of joining a conversation to a separate function and handle receiving out of sync message
* Add MlsFallbackStrategy to be injected from Koin Modules
* Add test dependencies for mockk and kotlinx-coroutines
* Remove Mockito dependency as it was not being used

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the SDK is offline it will miss some important events (MLS Welcome or Epoch changes).

### Causes (Optional)

There was no fallback for these issues and no final websocket endpoint to handle previous events.

### Solutions

Add a fallback strategy (verifying if conversation exists locally in CC and epoch differences) when receiving or sending a message.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

##### Test 1
- With the SDK offline
- Create a group and add the App to the conversation
- Turn the SDK on
- receive a message from this conversation (it will handle the fallback strategy)
- receive another message and it will be decrypted as expected.

##### Test 2
- With the SDK on
- create a conversation and add the App to the conversation
- receive a message
- Turn de SDK offline
- Add another user to the conversation
- Turn de SDK online
- receive a message (it will handle the fallback strategy)
- receive another message and it will decrypt as expected.

### Notes (Optional)

Some tech debt was added and will be discussed in a new proposed document with the team
