### PR TITLE
feat: Add get user api #WPB-17695

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -26,6 +26,7 @@ import com.wire.integrations.jvm.model.http.AppDataResponse
 import com.wire.integrations.jvm.model.http.FeaturesResponse
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
 import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
+import com.wire.integrations.jvm.model.http.user.UserResponse
 import io.ktor.websocket.Frame
 import kotlinx.coroutines.channels.ReceiveChannel
 
@@ -55,6 +56,8 @@ interface BackendClient {
     suspend fun sendMessage(mlsMessage: ByteArray)
 
     suspend fun getConversation(conversationId: QualifiedId): ConversationResponse
+
+    suspend fun getUserData(userId: QualifiedId): UserResponse
 
     suspend fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
@@ -29,6 +29,7 @@ import com.wire.integrations.jvm.model.http.AppDataResponse
 import com.wire.integrations.jvm.model.http.FeaturesResponse
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
 import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
+import com.wire.integrations.jvm.model.http.user.UserResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.websocket.webSocket
@@ -112,6 +113,10 @@ internal class BackendClientImpl internal constructor(
     }
 
     override suspend fun getConversation(conversationId: QualifiedId): ConversationResponse {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getUserData(userId: QualifiedId): UserResponse {
         TODO("Not yet implemented")
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
@@ -15,7 +15,6 @@
 
 package com.wire.integrations.jvm.config
 
-import com.wire.integrations.jvm.model.QualifiedId
 import org.koin.dsl.koinApplication
 import org.koin.fileProperties
 import java.util.UUID
@@ -51,12 +50,6 @@ internal object IsolatedKoinContext {
 
     fun getCryptographyStoragePassword(): String? =
         this.koinApp.koin.getProperty(CRYPTOGRAPHY_STORAGE_PASSWORD)
-
-    fun getApplicationQualifiedId(): QualifiedId =
-        QualifiedId(
-            checkNotNull(getApplicationId()),
-            checkNotNull(getApiHost())
-        )
 
     /**
      * Property Constants

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -16,7 +16,6 @@
 
 package com.wire.integrations.jvm.model
 
-import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.exception.WireException
 import java.util.UUID
 
@@ -69,7 +68,10 @@ sealed interface WireMessage {
                 return Text(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     text = text,
                     mentions = mentions,
                     expiresAfterMillis = expiresAfterMillis
@@ -172,7 +174,10 @@ sealed interface WireMessage {
                 return Composite(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     items = listOf(textItem) + buttonList
                 )
             }
@@ -249,7 +254,10 @@ sealed interface WireMessage {
                 return Knock(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     hotKnock = hotKnock,
                     expiresAfterMillis = expiresAfterMillis
                 )
@@ -293,7 +301,10 @@ sealed interface WireMessage {
                 return Location(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     latitude = latitude,
                     longitude = longitude,
                     name = name,
@@ -327,7 +338,10 @@ sealed interface WireMessage {
                 Deleted(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     messageId = messageId
                 )
         }
@@ -364,7 +378,10 @@ sealed interface WireMessage {
                 Receipt(
                     id = UUID.randomUUID(),
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     type = type,
                     messageIds = messages
                 )
@@ -400,7 +417,10 @@ sealed interface WireMessage {
                 return TextEdited(
                     id = originalMessageId,
                     conversationId = conversationId,
-                    sender = IsolatedKoinContext.getApplicationQualifiedId(),
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
                     newContent = text,
                     newMentions = mentions
                 )

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/user/UserResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/user/UserResponse.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.model.http.user
+
+import com.wire.integrations.jvm.model.CryptoProtocol
+import com.wire.integrations.jvm.model.QualifiedId
+import com.wire.integrations.jvm.utils.UUIDSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+data class UserResponse(
+    @SerialName("qualified_id")
+    val id: QualifiedId,
+    @Serializable(with = UUIDSerializer::class)
+    @SerialName("team")
+    val teamId: UUID?,
+    @SerialName("email")
+    val email: String?,
+    @SerialName("name")
+    val name: String,
+    @SerialName("handle")
+    val handle: String?,
+    @SerialName("accent_id")
+    val accentId: Long,
+    @SerialName("supported_protocols")
+    val supportedProtocols: List<CryptoProtocol>,
+    @SerialName("deleted")
+    val deleted: Boolean?
+)

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -18,6 +18,7 @@ package com.wire.integrations.sample
 import com.wire.integrations.jvm.WireAppSdk
 import com.wire.integrations.jvm.WireEventsHandlerSuspending
 import com.wire.integrations.jvm.model.AssetResource
+import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.integrations.jvm.model.WireMessage
 import com.wire.integrations.jvm.model.asset.AssetRetention
 import org.slf4j.LoggerFactory
@@ -162,6 +163,11 @@ fun main() {
     applicationManager.getStoredConversations().forEach {
         logger.info("Conversation: $it")
     }
+    val selfUser = QualifiedId(
+        id = UUID.fromString("ee159b66-fd70-4739-9bae-23c96a02cb09"),
+        domain = "chala.wire.link"
+    )
+    logger.info(applicationManager.getUser(selfUser).toString())
     logger.info("Wire backend domain: ${applicationManager.getBackendConfiguration().domain}")
 
     // Use wireAppSdk.stop() to stop the SDK or just stop it with Ctrl+C/Cmd+C


### PR DESCRIPTION
* Allow devs to interact with new user API
* Remove IsolatedKoinContext.kt references from WireMessage.kt, allowing factories to be used without Koin running

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Devs could not fetch user data, for example to get the handle or name

### Solutions

Add api in client and applicationManager

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
