### PR TITLE
feat: Handle Reaction, InCallEmoji and InCallHandRaise #WPB-17377

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerDefault.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerDefault.kt
@@ -92,6 +92,18 @@ abstract class WireEventsHandlerDefault : WireEventsHandler() {
         logger.info("Received event: onTextEdited: $wireMessage")
     }
 
+    open fun onReaction(wireMessage: WireMessage.Reaction) {
+        logger.info("Received event: onReaction: $wireMessage")
+    }
+
+    open fun onInCallEmoji(wireMessage: WireMessage.InCallEmoji) {
+        logger.info("Received event: onInCallEmoji: $wireMessage")
+    }
+
+    open fun onInCallHandRaise(wireMessage: WireMessage.InCallHandRaise) {
+        logger.info("Received event: onInCallHandRaise: $wireMessage")
+    }
+
     /**
      * One or more users have joined a conversation accessible by the Wire App.
      * This event is triggered when the App is already in the conversation and new users joins.

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerSuspending.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireEventsHandlerSuspending.kt
@@ -97,6 +97,18 @@ abstract class WireEventsHandlerSuspending : WireEventsHandler() {
         logger.info("Received event: onTextEdited: $wireMessage")
     }
 
+    open suspend fun onReaction(wireMessage: WireMessage.Reaction) {
+        logger.info("Received event: onReaction: $wireMessage")
+    }
+
+    open suspend fun onInCallEmoji(wireMessage: WireMessage.InCallEmoji) {
+        logger.info("Received event: onInCallEmoji: $wireMessage")
+    }
+
+    open suspend fun onInCallHandRaise(wireMessage: WireMessage.InCallHandRaise) {
+        logger.info("Received event: onInCallHandRaise: $wireMessage")
+    }
+
     /**
      * One or more users have joined a conversation accessible by the Wire App.
      * This event is triggered when the App is already in the conversation and new users joins.

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -428,6 +428,56 @@ sealed interface WireMessage {
         }
     }
 
+    data class Reaction(
+        override val id: UUID,
+        override val conversationId: QualifiedId,
+        override val sender: QualifiedId,
+        val messageId: String,
+        val emojiSet: Set<String>
+    ) : WireMessage {
+        companion object {
+            /**
+             * Creates a Reaction message with minimal required parameters.
+             *
+             * @param conversationId The qualified ID of the conversation
+             * @param messageId The ID of the message that will receive the Reaction
+             * @param emojiSet A Set<String> of emojis to be sent
+             * @return A new TextEdited message with the original received ID.
+             */
+            @JvmStatic
+            fun create(
+                conversationId: QualifiedId,
+                messageId: String,
+                emojiSet: Set<String> = emptySet()
+            ): Reaction {
+                return Reaction(
+                    id = UUID.randomUUID(),
+                    conversationId = conversationId,
+                    sender = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = UUID.randomUUID().toString()
+                    ),
+                    messageId = messageId,
+                    emojiSet = emojiSet
+                )
+            }
+        }
+    }
+
+    data class InCallEmoji(
+        override val id: UUID,
+        override val conversationId: QualifiedId,
+        override val sender: QualifiedId,
+        val emojis: Map<String, Int>
+    ) : WireMessage
+
+    data class InCallHandRaise(
+        override val id: UUID,
+        override val conversationId: QualifiedId,
+        override val sender: QualifiedId,
+        val isHandUp: Boolean
+    ) : WireMessage
+
     data object Ignored : WireMessage {
         override val id: UUID
             get() = throw WireException.InvalidParameter("Ignored message, no ID")

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufSerializer.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufSerializer.kt
@@ -17,7 +17,6 @@
 package com.wire.integrations.jvm.model.protobuf
 
 import com.google.protobuf.ByteString
-import com.google.protobuf.kotlin.set
 import com.wire.integrations.jvm.exception.WireException
 import com.wire.integrations.jvm.model.WireMessage
 import com.wire.integrations.protobuf.messages.Messages
@@ -27,10 +26,13 @@ import com.wire.integrations.protobuf.messages.Messages.Composite
 import com.wire.integrations.protobuf.messages.Messages.Confirmation
 import com.wire.integrations.protobuf.messages.Messages.Ephemeral
 import com.wire.integrations.protobuf.messages.Messages.GenericMessage
+import com.wire.integrations.protobuf.messages.Messages.InCallEmoji
+import com.wire.integrations.protobuf.messages.Messages.InCallHandRaise
 import com.wire.integrations.protobuf.messages.Messages.Knock
 import com.wire.integrations.protobuf.messages.Messages.Location
 import com.wire.integrations.protobuf.messages.Messages.MessageDelete
 import com.wire.integrations.protobuf.messages.Messages.MessageEdit
+import com.wire.integrations.protobuf.messages.Messages.Reaction
 
 /**
  * Object class mapper for mapping [WireMessage] to [GenericMessage] (Protobuf) returning
@@ -39,7 +41,7 @@ import com.wire.integrations.protobuf.messages.Messages.MessageEdit
  * To be used when sending a message from [WireApplicationManager]
  * before reaching [CoreCryptoClient]
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "CyclomaticComplexMethod")
 object ProtobufSerializer {
     fun toGenericMessageByteArray(wireMessage: WireMessage): ByteArray {
         val genericMessage = GenericMessage
@@ -58,6 +60,9 @@ object ProtobufSerializer {
             is WireMessage.Deleted -> packDeleted(wireMessage, genericMessage)
             is WireMessage.Receipt -> packReceipt(wireMessage, genericMessage)
             is WireMessage.TextEdited -> packTextEdited(wireMessage, genericMessage)
+            is WireMessage.Reaction -> packReaction(wireMessage, genericMessage)
+            is WireMessage.InCallEmoji -> packInCallEmoji(wireMessage, genericMessage)
+            is WireMessage.InCallHandRaise -> packInCallHandRaise(wireMessage, genericMessage)
 
             is WireMessage.Ignored,
             is WireMessage.Unknown -> throw WireException.CryptographicSystemError(
@@ -288,4 +293,33 @@ object ProtobufSerializer {
                         )
                     )
             )
+
+    private fun packReaction(
+        wireMessage: WireMessage.Reaction,
+        genericMessage: GenericMessage.Builder
+    ): GenericMessage.Builder =
+        genericMessage
+            .setReaction(
+                Reaction.newBuilder()
+                    .setEmoji(
+                        wireMessage.emojiSet.map { it.trim() }.filter { it.isNotBlank() }
+                            .joinToString(separator = ",") { it }
+                    )
+                    .setMessageId(wireMessage.messageId)
+                    .build()
+            )
+
+    private fun packInCallEmoji(
+        wireMessage: WireMessage.InCallEmoji,
+        genericMessage: GenericMessage.Builder
+    ): GenericMessage.Builder =
+        genericMessage
+            .setInCallEmoji(InCallEmoji.newBuilder().putAllEmojis(wireMessage.emojis))
+
+    private fun packInCallHandRaise(
+        wireMessage: WireMessage.InCallHandRaise,
+        genericMessage: GenericMessage.Builder
+    ): GenericMessage.Builder =
+        genericMessage
+            .setInCallHandRaise(InCallHandRaise.newBuilder().setIsHandUp(wireMessage.isHandUp))
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -250,6 +250,9 @@ internal class EventsRouter internal constructor(
                 is WireMessage.Deleted -> wireEventsHandler.onDeletedMessage(wireMessage)
                 is WireMessage.Receipt -> wireEventsHandler.onReceiptConfirmation(wireMessage)
                 is WireMessage.TextEdited -> wireEventsHandler.onTextEdited(wireMessage)
+                is WireMessage.Reaction -> wireEventsHandler.onReaction(wireMessage)
+                is WireMessage.InCallEmoji -> wireEventsHandler.onInCallEmoji(wireMessage)
+                is WireMessage.InCallHandRaise -> wireEventsHandler.onInCallHandRaise(wireMessage)
                 is WireMessage.Ignored -> logger.warn("Ignored event received.")
                 is WireMessage.Unknown -> logger.warn("Unknown event received.")
             }
@@ -265,6 +268,9 @@ internal class EventsRouter internal constructor(
                 is WireMessage.Deleted -> wireEventsHandler.onDeletedMessage(wireMessage)
                 is WireMessage.Receipt -> wireEventsHandler.onReceiptConfirmation(wireMessage)
                 is WireMessage.TextEdited -> wireEventsHandler.onTextEdited(wireMessage)
+                is WireMessage.Reaction -> wireEventsHandler.onReaction(wireMessage)
+                is WireMessage.InCallEmoji -> wireEventsHandler.onInCallEmoji(wireMessage)
+                is WireMessage.InCallHandRaise -> wireEventsHandler.onInCallHandRaise(wireMessage)
                 is WireMessage.Ignored -> logger.warn("Ignored event received.")
                 is WireMessage.Unknown -> logger.warn("Unknown event received.")
             }

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -77,8 +77,16 @@ fun main() {
                     messages = listOf(wireMessage.id.toString())
                 )
 
+                // Add a reaction emoji to the received message
+                val reaction = WireMessage.Reaction.create(
+                    conversationId = wireMessage.conversationId,
+                    messageId = wireMessage.id.toString(),
+                    emojiSet = setOf("🤝")
+                )
+
                 manager.sendMessageSuspending(message = message)
                 manager.sendMessageSuspending(message = receipt)
+                manager.sendMessageSuspending(message = reaction)
             }
 
             override suspend fun onAsset(wireMessage: WireMessage.Asset) {


### PR DESCRIPTION
* Add new WireMessage data class for each new message type
* Add event receiver types on WireEventsHandler
* [SAMPLE] Add example on sending a reaction to a received message

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

No handling for messages of type: [Reaction, InCallEmoji, InCallHandRaise]

### Causes (Optional)

Not implemented previously

### Solutions

- Add new WireMessage data class for each new message type
- Add event receiver types on WireEventsHandler
- [SAMPLE] Add example on sending a reaction to a received message
