### PR TITLE
feat: Migrate CoreCrypto to v7.0.1 #WPB-17797

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     }
 
     implementation(platform("io.insert-koin:koin-bom:4.0.4"))
-    implementation("io.insert-koin:koin-core")
+    implementation("io.insert-koin:koin-core:4.0.4")
     implementation("ch.qos.logback:logback-classic:1.5.18")
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
@@ -59,8 +59,8 @@ dependencies {
     implementation("io.ktor:ktor-client-websockets:$ktorVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
-    implementation("com.wire:core-crypto-jvm:4.1.0")
-    implementation("com.wire:core-crypto-uniffi-jvm:4.1.0")
+    implementation("com.wire:core-crypto-jvm:7.0.1")
+    implementation("com.wire:core-crypto-uniffi-jvm:7.0.1")
     implementation("app.cash.sqldelight:sqlite-driver:2.1.0")
     implementation("app.cash.sqldelight:sqlite-3-24-dialect:2.1.0")
     implementation("org.zalando:logbook-core:3.12.1")

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
@@ -38,6 +38,11 @@ class WireAppSdk(
     private val executor = Executors.newSingleThreadExecutor()
 
     init {
+        require(cryptographyStoragePassword.length == MIN_CRYPTOGRAPHY_STORAGE_PASSWORD) {
+            "cryptographyStoragePassword must be of $MIN_CRYPTOGRAPHY_STORAGE_PASSWORD " +
+                "characters length."
+        }
+
         IsolatedKoinContext.start()
         IsolatedKoinContext.setApplicationId(applicationId)
         IsolatedKoinContext.setApiHost(apiHost)
@@ -88,5 +93,9 @@ class WireAppSdk(
         }
 
         IsolatedKoinContext.koinApp.koin.loadModules(listOf(dynamicModule))
+    }
+
+    private companion object {
+        const val MIN_CRYPTOGRAPHY_STORAGE_PASSWORD = 32
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/config/IsolatedKoinContext.kt
@@ -64,10 +64,11 @@ internal object IsolatedKoinContext {
     fun getApiToken(): String? = this.koinApp.koin.getProperty(API_TOKEN)
 
     fun setCryptographyStoragePassword(value: String) {
-        this.koinApp.koin.setProperty(CRYPTOGRAPHY_STORAGE_PASSWORD, value)
+        val cryptoPassword = value.toByteArray()
+        this.koinApp.koin.setProperty(CRYPTOGRAPHY_STORAGE_PASSWORD, cryptoPassword)
     }
 
-    fun getCryptographyStoragePassword(): String? =
+    fun getCryptographyStoragePassword(): ByteArray? =
         this.koinApp.koin.getProperty(CRYPTOGRAPHY_STORAGE_PASSWORD)
 
     /**

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -4,6 +4,7 @@ import com.wire.crypto.Ciphersuite
 import com.wire.crypto.Ciphersuites
 import com.wire.crypto.ClientId
 import com.wire.crypto.CoreCrypto
+import com.wire.crypto.DatabaseKey
 import com.wire.crypto.GroupInfo
 import com.wire.crypto.MLSGroupId
 import com.wire.crypto.MLSKeyPackage
@@ -53,6 +54,7 @@ internal class CoreCryptoClient private constructor(
             val coreCrypto = CoreCrypto.invoke(
                 keystore = keystorePath,
                 databaseKey = IsolatedKoinContext.getCryptographyStoragePassword()
+                    ?.let { DatabaseKey(it) }
                     ?: throw InvalidParameter("Cryptography password missing")
             )
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/MlsTransportImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/MlsTransportImpl.kt
@@ -16,16 +16,21 @@
 
 package com.wire.integrations.jvm.crypto
 
+import com.wire.crypto.CommitBundle
 import com.wire.crypto.MlsTransport
-import com.wire.crypto.uniffi.CommitBundle
-import com.wire.crypto.uniffi.MlsTransportResponse
+import com.wire.crypto.MlsTransportResponse
 import com.wire.integrations.jvm.client.BackendClient
 
 internal class MlsTransportImpl(
     private val backendClient: BackendClient
 ) : MlsTransport {
     override suspend fun sendCommitBundle(commitBundle: CommitBundle): MlsTransportResponse {
-        backendClient.uploadCommitBundle(parseBundleIntoSingleByteArray(commitBundle))
+        backendClient.uploadCommitBundle(
+            commitBundle = parseBundleIntoSingleByteArray(
+                bundle = commitBundle
+            )
+        )
+
         return MlsTransportResponse.Success
     }
 
@@ -42,6 +47,8 @@ internal class MlsTransportImpl(
      * @param bundle the CommitBundle to parse
      */
     private fun parseBundleIntoSingleByteArray(bundle: CommitBundle): ByteArray {
-        return bundle.commit + bundle.groupInfo.payload + (bundle.welcome ?: ByteArray(0))
+        return bundle.commit.value +
+            bundle.groupInfoBundle.payload.value +
+            (bundle.welcome?.value ?: ByteArray(0))
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -158,7 +158,16 @@ internal class EventsRouter internal constructor(
                             timestamp = event.time
                         )
                     } catch (exception: MlsException) {
-                        logger.debug("Message decryption failed", exception)
+                        logger.debug("Message decryption failed, MlsException: ", exception)
+                        mlsFallbackStrategy.verifyConversationOutOfSync(
+                            mlsGroupId = groupId,
+                            conversationId = event.qualifiedConversation
+                        )
+                    } catch (exception: CoreCryptoException.Mls) {
+                        logger.debug(
+                            "Message decryption failed, CoreCryptoException.Mls:",
+                            exception
+                        )
                         mlsFallbackStrategy.verifyConversationOutOfSync(
                             mlsGroupId = groupId,
                             conversationId = event.qualifiedConversation

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
@@ -21,11 +21,14 @@ import com.wire.crypto.MLSGroupId
 import com.wire.integrations.jvm.client.BackendClient
 import com.wire.integrations.jvm.crypto.CryptoClient
 import com.wire.integrations.jvm.model.QualifiedId
+import org.slf4j.LoggerFactory
 
 class MlsFallbackStrategy internal constructor(
     private val backendClient: BackendClient,
     private val cryptoClient: CryptoClient
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     /**
      * Verifies if a conversation is out of sync and re-syncs (re-joining or updating the epoch)
      *
@@ -43,6 +46,12 @@ class MlsFallbackStrategy internal constructor(
         val conversationExists = cryptoClient.conversationExists(mlsGroupId = mlsGroupId)
         val fetchedConversation = backendClient.getConversation(conversationId = conversationId)
         val currentEpoch = cryptoClient.conversationEpoch(mlsGroupId = mlsGroupId)
+
+        logger.info(
+            "Verifying Fallback Strategy for conversationId: ${conversationId}, " +
+                "exists: $conversationExists " +
+                "epoch: local[$currentEpoch] < remote[${fetchedConversation.epoch}]"
+        )
 
         if (!conversationExists || currentEpoch.toLong() < fetchedConversation.epoch) {
             val groupInfo = backendClient.getConversationGroupInfo(

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
@@ -121,5 +121,5 @@ object TestUtils {
     private val APPLICATION_ID = UUID.randomUUID()
     private const val API_TOKEN = "dummyToken"
     private const val API_HOST = "http://localhost:8086"
-    private const val CRYPTOGRAPHY_STORAGE_PASSWORD = "dummyPassword"
+    const val CRYPTOGRAPHY_STORAGE_PASSWORD = "myDummyPasswordOfRandom32BytesCH"
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/WireAppSdkTest.kt
@@ -17,6 +17,7 @@ package com.wire.integrations.jvm
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.wire.integrations.jvm.TestUtils.CRYPTOGRAPHY_STORAGE_PASSWORD
 import com.wire.integrations.jvm.TestUtils.V
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.model.WireMessage
@@ -83,7 +84,6 @@ class WireAppSdkTest {
         private val APPLICATION_ID = UUID.randomUUID()
         private const val API_TOKEN = "dummyToken"
         private const val API_HOST = "http://localhost:8086"
-        private const val CRYPTOGRAPHY_STORAGE_PASSWORD = "dummyPassword"
 
         private val wireMockServer = WireMockServer(8086)
 

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClientTest.kt
@@ -56,7 +56,7 @@ class CoreCryptoClientTest {
             )
             cryptoClient.close()
 
-            IsolatedKoinContext.setCryptographyStoragePassword("apple🍎")
+            IsolatedKoinContext.setCryptographyStoragePassword("anotherPasswordOfRandom32BytesCH")
             assertThrows<com.wire.crypto.uniffi.CoreCryptoException.Mls> {
                 CoreCryptoClient.create(
                     appClientId = appClientId,
@@ -186,7 +186,7 @@ class CoreCryptoClientTest {
         fun before() {
             // Testing that full UTF-8 is accepted on storage password
             IsolatedKoinContext.start()
-            IsolatedKoinContext.setCryptographyStoragePassword("banana🍌")
+            IsolatedKoinContext.setCryptographyStoragePassword("myDummyPasswordOfRandom32BytesCH")
         }
 
         val CONVERSATION_ID = QualifiedId(

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -24,7 +24,6 @@ import com.wire.crypto.MLSGroupId
 import com.wire.crypto.MLSKeyPackage
 import com.wire.crypto.MlsException
 import com.wire.crypto.Welcome
-import com.wire.crypto.toByteArray
 import com.wire.integrations.jvm.TestUtils
 import com.wire.integrations.jvm.TestUtils.V
 import com.wire.integrations.jvm.WireEventsHandlerSuspending

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MlsTransportLastWelcome.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MlsTransportLastWelcome.kt
@@ -18,8 +18,8 @@ package com.wire.integrations.jvm.utils
 
 import com.wire.crypto.MlsTransport
 import com.wire.crypto.Welcome
-import com.wire.crypto.uniffi.CommitBundle
-import com.wire.crypto.uniffi.MlsTransportResponse
+import com.wire.crypto.CommitBundle
+import com.wire.crypto.MlsTransportResponse
 
 /**
  * A simple implementation of [MlsTransport] that stores the last welcome message,
@@ -30,7 +30,7 @@ class MlsTransportLastWelcome : MlsTransport {
 
     override suspend fun sendCommitBundle(commitBundle: CommitBundle): MlsTransportResponse {
         commitBundle.welcome?.let {
-            groupWelcomeMap = Welcome(it)
+            groupWelcomeMap = Welcome(it.value)
         }
 
         return MlsTransportResponse.Success

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -27,7 +27,7 @@ fun main() {
         applicationId = UUID.randomUUID(),
         apiToken = "myApiToken",
         apiHost = "https://nginz-https.chala.wire.link",
-        cryptographyStoragePassword = "myDummyPassword",
+        cryptographyStoragePassword = "myDummyPasswordOfRandom32BytesCH",
         wireEventsHandler = SampleEventsHandler()
     )
 


### PR DESCRIPTION
* Force specific version usage of koin-core dependency
* Update CoreCrypto version to v7.0.1
* Change return type of getCryptographyStoragePassword from String to ByteArray
* When setting  setCryptographyStoragePassword convert to ByteArray when saving
* Change MlsTransport implementation to stop using uniffi imports and rather use core CoreCrypto models
* In EventsRouter, catch additional core CoreCrypto Mls exception
* Add logging for MlsFallbackStrategy
* Force require cryptography storage password to be exact 32 characters long (as String)
* Pass correct DatabaseKey model from CoreCrypto instead of just String as password
* Adjust tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

An old (v4) CoreCrypto implementation were being used

### Causes (Optional)

Not updated in a long time

### Solutions

Update to version 7.0.1 and adjust to changes since version 4

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution
