### PR TITLE
feat: Use environment variables instead of property files #WPB-17838

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ dependencies {
 </dependency>
 ```
 
+## Environment Variables
+```dotenv
+WIRE_SDK_USER_ID=abcd-1234-efgh-5678
+WIRE_SDK_EMAIL=your_email@domain.com
+WIRE_SDK_PASSWORD=randomPassword
+WIRE_SDK_CLIENT=dd228f6343d3916
+WIRE_SDK_ENVIRONMENT=my.domain.link
+```
+
 ## Build the project
 
 ```shell
@@ -74,7 +83,7 @@ and later you want to switch to another, you may need to move/delete the `apps.d
 You can define the implementation of BackendClient to use, by changing it in the Modules.kt file.
 
 * BackendClientDemo targets the Wire backend for development purposes, it uses the Client API for
-  testing instead of the Application API
+  testing instead of the Application API and also some environment variables specified above.
 * BackendClientImpl is the real implementation of the SDK, targeting the Wire backend as an
   Application
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
@@ -59,7 +59,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import java.util.Base64
-import java.util.Properties
 import java.util.UUID
 
 /**
@@ -370,38 +369,23 @@ internal class BackendClientDemo internal constructor(
         const val HEADER_ASSET_TOKEN = "Asset-Token"
         const val TOKEN_EXPIRATION_MS = 14 * 60 * 1000 // 14 minutes in milliseconds
 
-        val DEMO_USER_EMAIL: String by lazy {
-            DemoProperties.properties.getProperty(
-                "demo.user.email",
-                "integrations-admin@wire.com"
-            )
-        }
-        val DEMO_USER_ID: UUID by lazy {
+        val DEMO_USER_ID: UUID =
             UUID.fromString(
-                DemoProperties.properties.getProperty(
-                    "demo.user.id",
-                    "ee159b66-fd70-4739-9bae-23c96a02cb09"
-                )
+                System.getenv("WIRE_SDK_USER_ID")
+                    ?: "ee159b66-fd70-4739-9bae-23c96a02cb09"
             )
-        }
-        val DEMO_USER_PASSWORD: String by lazy {
-            DemoProperties.properties.getProperty(
-                "demo.user.password",
-                "Aqa123456!"
-            )
-        }
-        val DEMO_USER_CLIENT: String by lazy {
-            DemoProperties.properties.getProperty(
-                "demo.user.client",
-                "fc088e7f958fb833"
-            )
-        }
-        val DEMO_ENVIRONMENT: String by lazy {
-            DemoProperties.properties.getProperty(
-                "demo.environment",
-                "chala.wire.link"
-            )
-        }
+
+        val DEMO_USER_EMAIL: String =
+            System.getenv("WIRE_SDK_EMAIL") ?: "integrations-admin@wire.com"
+
+        val DEMO_USER_PASSWORD: String =
+            System.getenv("WIRE_SDK_PASSWORD") ?: "Aqa123456!"
+
+        val DEMO_USER_CLIENT: String =
+            System.getenv("WIRE_SDK_CLIENT") ?: "fc088e7f958fb833"
+
+        val DEMO_ENVIRONMENT: String =
+            System.getenv("WIRE_SDK_ENVIRONMENT") ?: "chala.wire.link"
     }
 }
 
@@ -416,16 +400,3 @@ data class LoginResponse(
     @SerialName("access_token") val accessToken: String,
     @SerialName("expires_in") val expiresIn: Int
 )
-
-/**
- * Loads demo properties from 'demo.properties' file in the project root (git ignored)
- * If the file is missing, default values are used.
- */
-internal object DemoProperties {
-    internal val properties = Properties()
-
-    init {
-        DemoProperties::class.java.getResourceAsStream("/demo.properties")
-            ?.use { properties.load(it) }
-    }
-}


### PR DESCRIPTION
* Remove usage of Properties by file
* Add reading of property by System environment variables
* update README.md

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were using a file `demo.properties` to hold variables/values that we use currently for the `BackendClientDemo`

### Solutions

Remove usage for these Properties by file and start using System environment variables for future usage in shipping Apps with Docker or other platforms.