### PR TITLE
feat: Handle one-to-one conversations #WPB-17961

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationResponse.kt
@@ -21,11 +21,6 @@ import com.wire.integrations.jvm.utils.UUIDSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class ConversationResponse(
@@ -42,17 +37,19 @@ data class ConversationResponse(
     val epoch: Long,
     @SerialName("members")
     val members: ConversationMembers,
-    @Serializable(with = ConversationTypeSerializer::class)
+    @SerialName("type")
     val type: Type
 ) {
-    enum class Type(val id: Int) {
-        GROUP(0),
-        SELF(1),
-        ONE_TO_ONE(2);
+    @Serializable
+    enum class Type {
+        @SerialName("0")
+        GROUP,
 
-        companion object {
-            fun fromId(id: Int): Type = entries.first { type -> type.id == id }
-        }
+        @SerialName("1")
+        SELF,
+
+        @SerialName("2")
+        ONE_TO_ONE
     }
 }
 
@@ -69,17 +66,3 @@ data class ConversationMemberOther(
     @SerialName("conversation_role")
     val conversationRole: ConversationRole
 )
-
-class ConversationTypeSerializer : KSerializer<ConversationResponse.Type> {
-    override val descriptor = PrimitiveSerialDescriptor("type", PrimitiveKind.INT)
-
-    override fun serialize(
-        encoder: Encoder,
-        value: ConversationResponse.Type
-    ): Unit = encoder.encodeInt(value.id)
-
-    override fun deserialize(decoder: Decoder): ConversationResponse.Type {
-        val rawValue = decoder.decodeInt()
-        return ConversationResponse.Type.fromId(rawValue)
-    }
-}

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
@@ -160,7 +160,8 @@ class MlsFallbackStrategyTest {
             groupId = MLS_GROUP_ID.toString(),
             name = "Random Conversation",
             epoch = 0L,
-            members = ConversationMembers(others = emptyList())
+            members = ConversationMembers(others = emptyList()),
+            type = ConversationResponse.Type.GROUP
         )
     }
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -89,6 +89,39 @@ class WireEventsIntegrationTest {
         // Setup
         TestUtils.setupWireMockStubs(wireMockServer = wireMockServer)
 
+        wireMockServer.stubFor(
+            WireMock.get(
+                WireMock.urlPathTemplate("/$V/conversations/{conversationDomain}/{conversationId}")
+            ).willReturn(
+                WireMock.okJson(
+                    """
+                        {
+                            "qualified_id": {
+                                "id": "${CONVERSATION_ID.id}",
+                                "domain": "${CONVERSATION_ID.domain}"
+                            },
+                            "name": "Test conversation",
+                            "epoch": 0,
+                            "members": {
+                                "others": [
+                                    {
+                                        "qualified_id": {
+                                            "id": "${UUID.randomUUID()}",
+                                            "domain": "${CONVERSATION_ID.domain}"
+                                        },
+                                        "conversation_role": "wire_admin"
+                                    }
+                                ]
+                            },
+                            "group_id": "${Base64.getEncoder().encodeToString(MLS_GROUP_ID.value)}",
+                            "team": "${TEAM_ID.value}",
+                            "type": 0
+                        }
+                    """.trimIndent()
+                )
+            )
+        )
+
         // Create SDK with our custom handler
         TestUtils.setupSdk(wireEventsHandler)
 
@@ -197,6 +230,38 @@ class WireEventsIntegrationTest {
     fun givenNewMLSMessageEventWhenRouterProcessesItThenMessageIsDecryptedAndHandled() {
         // Setup
         TestUtils.setupWireMockStubs(wireMockServer = wireMockServer)
+        wireMockServer.stubFor(
+            WireMock.get(
+                WireMock.urlPathTemplate("/$V/conversations/{conversationDomain}/{conversationId}")
+            ).willReturn(
+                WireMock.okJson(
+                    """
+                        {
+                            "qualified_id": {
+                                "id": "${CONVERSATION_ID.id}",
+                                "domain": "${CONVERSATION_ID.domain}"
+                            },
+                            "name": "Test conversation",
+                            "epoch": 0,
+                            "members": {
+                                "others": [
+                                    {
+                                        "qualified_id": {
+                                            "id": "${UUID.randomUUID()}",
+                                            "domain": "${CONVERSATION_ID.domain}"
+                                        },
+                                        "conversation_role": "wire_admin"
+                                    }
+                                ]
+                            },
+                            "group_id": "${Base64.getEncoder().encodeToString(MLS_GROUP_ID.value)}",
+                            "team": "${TEAM_ID.value}",
+                            "type": 0
+                        }
+                    """.trimIndent()
+                )
+            )
+        )
 
         // Create SDK with our custom handler
         TestUtils.setupSdk(wireEventsHandler)


### PR DESCRIPTION
* Make `name` nullable from ConversationResponse
* Add `type` attribute in ConversationResponse
* Based on `type` from conversation, determine what will be the saved conversation name
* Adjust tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving a MLSWelcome for a 1:1 conversation it would fail.

### Causes (Optional)

It was failing because the `name` attribute in `ConversationResponse` was non-nullable, and for 1:1 conversations the received name is null as it is supposed to used the other user name as the conversation name.

### Solutions

Make `name` attribute in `ConversationResponse` nullable.
