### PR TITLE
chore: Remove Websocket MessageCount

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/EventAcknowledgeRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/EventAcknowledgeRequest.kt
@@ -35,12 +35,6 @@ data class EventAcknowledgeRequest(
             )
         }
 
-        fun countAck(): EventAcknowledgeRequest {
-            return EventAcknowledgeRequest(
-                type = AcknowledgeType.ACK_MESSAGE_COUNT
-            )
-        }
-
         fun notificationMissedAck(): EventAcknowledgeRequest {
             return EventAcknowledgeRequest(
                 type = AcknowledgeType.ACK_FULL_SYNC

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/ConsumableNotificationResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/ConsumableNotificationResponse.kt
@@ -31,12 +31,6 @@ sealed class ConsumableNotificationResponse {
     ) : ConsumableNotificationResponse()
 
     @Serializable
-    @SerialName("message_count")
-    data class MessageCount(
-        @SerialName("data") val data: NotificationCount
-    ) : ConsumableNotificationResponse()
-
-    @Serializable
     @SerialName("notifications_missed")
     data object MissedNotification : ConsumableNotificationResponse()
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListener.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListener.kt
@@ -89,12 +89,6 @@ internal class WireTeamEventsListener internal constructor(
                 }
             }
 
-            is ConsumableNotificationResponse.MessageCount -> {
-                logger.info("Websocket back online, ${notification.data.count} events to fetch")
-                val ackRequest = EventAcknowledgeRequest.countAck()
-                ackEvent(ackRequest, session)
-            }
-
             is ConsumableNotificationResponse.MissedNotification -> {
                 logger.warn("App was offline for too long, missed some notifications")
                 val ackRequest = EventAcknowledgeRequest.notificationMissedAck()

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListenerTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListenerTest.kt
@@ -21,7 +21,6 @@ import com.wire.integrations.jvm.model.http.ConsumableNotificationResponse
 import com.wire.integrations.jvm.model.http.EventContentDTO
 import com.wire.integrations.jvm.model.http.EventDataDTO
 import com.wire.integrations.jvm.model.http.EventResponse
-import com.wire.integrations.jvm.model.http.NotificationCount
 import com.wire.integrations.jvm.utils.KtxSerializer
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
@@ -57,10 +56,6 @@ class WireTeamEventsListenerTest {
 
             val missedNotification = ConsumableNotificationResponse.MissedNotification
             val encodedMissing = encodeNotification(missedNotification)
-            val messageCount = ConsumableNotificationResponse.MessageCount(
-                data = NotificationCount(count = 5U)
-            )
-            val encodedCount = encodeNotification(messageCount)
             val eventNotification = ConsumableNotificationResponse.EventNotification(
                 data = EventDataDTO(
                     event = eventResponse,
@@ -82,7 +77,6 @@ class WireTeamEventsListenerTest {
             launch { listener.connect() }
 
             incomingChannel.send(Frame.Binary(false, encodedMissing.encodeToByteArray()))
-            incomingChannel.send(Frame.Binary(false, encodedCount.encodeToByteArray()))
             incomingChannel.send(Frame.Binary(false, encodedEvent.encodeToByteArray()))
             delay(100) // Allow time for processing
 
@@ -94,7 +88,7 @@ class WireTeamEventsListenerTest {
                 outgoingChannel.tryReceive().getOrNull()
             }.count()
 
-            assertEquals(3, count)
+            assertEquals(2, count)
 
             incomingChannel.close()
             outgoingChannel.close()


### PR DESCRIPTION
* On Backend API v9 MessageCount was removed

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On API v9 MessageCount was removed and thus causing and endless closing and reconnection of the websocket

### Solutions

Remove sending of ack_message_count and MessageCount in general
