### PR TITLE
chore: Ignore Websocket MessageCount

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -73,6 +73,6 @@ interface BackendClient {
     ): AssetUploadResponse
 
     companion object {
-        const val API_VERSION = "v8"
+        const val API_VERSION = "v9"
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/ConsumableNotificationResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/ConsumableNotificationResponse.kt
@@ -31,6 +31,12 @@ sealed class ConsumableNotificationResponse {
     ) : ConsumableNotificationResponse()
 
     @Serializable
+    @SerialName("message_count")
+    data class MessageCount(
+        @SerialName("data") val data: NotificationCount
+    ) : ConsumableNotificationResponse()
+
+    @Serializable
     @SerialName("notifications_missed")
     data object MissedNotification : ConsumableNotificationResponse()
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListener.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireTeamEventsListener.kt
@@ -89,6 +89,10 @@ internal class WireTeamEventsListener internal constructor(
                 }
             }
 
+            is ConsumableNotificationResponse.MessageCount -> {
+                logger.info("Websocket back online, ${notification.data.count} events to fetch")
+            }
+
             is ConsumableNotificationResponse.MissedNotification -> {
                 logger.warn("App was offline for too long, missed some notifications")
                 val ackRequest = EventAcknowledgeRequest.notificationMissedAck()


### PR DESCRIPTION
* Bring back MessageCount("message_count") response class
* Listen in websocket frame but ignore ACK

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Despite not needing to send an `ACK` for MessageCount("message_count") from the websocket anymore we still need to receive it (but ignore) until https://github.com/wireapp/wire-server/pull/4631 is merged.

### Solutions

- Update backend version to v9
- Bring back MessageCount
- Listen to MessageCount from the websocket but ignore/don't send an ACK
