### PR TITLE
fix: TextEdited not updating when sent

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/WireMessage.kt
@@ -499,6 +499,7 @@ sealed interface WireMessage {
         override val id: UUID,
         override val conversationId: QualifiedId,
         override val sender: QualifiedId,
+        val replacingMessageId: UUID,
         val newContent: String,
         val newLinkPreviews: List<LinkPreview> = emptyList(),
         val newMentions: List<Mention> = emptyList()
@@ -507,7 +508,7 @@ sealed interface WireMessage {
             /**
              * Creates a TextEdited message with minimal required parameters.
              *
-             * @param originalMessageId The UUID of the original message to be edited.
+             * @param replacingMessageId The UUID of the original message to be edited.
              * @param conversationId The qualified ID of the conversation
              * @param text The text content of the message
              * @param mentions List of [Mention] included in the text
@@ -515,13 +516,14 @@ sealed interface WireMessage {
              */
             @JvmStatic
             fun create(
-                originalMessageId: UUID,
+                replacingMessageId: UUID,
                 conversationId: QualifiedId,
                 text: String,
                 mentions: List<Mention> = emptyList()
             ): TextEdited {
                 return TextEdited(
-                    id = originalMessageId,
+                    id = UUID.randomUUID(),
+                    replacingMessageId = replacingMessageId,
                     conversationId = conversationId,
                     sender = QualifiedId(
                         id = UUID.randomUUID(),

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufDeserializer.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufDeserializer.kt
@@ -383,7 +383,8 @@ object ProtobufDeserializer {
                     MessageMentionMapper.fromProtobuf(it)
                 }
                 WireMessage.TextEdited(
-                    id = UUID.fromString(replacingMessageId),
+                    id = UUID.fromString(genericMessage.messageId),
+                    replacingMessageId = UUID.fromString(replacingMessageId),
                     conversationId = conversationId,
                     sender = sender,
                     newContent = genericMessage.text.content,

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufSerializer.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/protobuf/ProtobufSerializer.kt
@@ -346,7 +346,7 @@ object ProtobufSerializer {
             .setEdited(
                 MessageEdit
                     .newBuilder()
-                    .setReplacingMessageId(wireMessage.id.toString())
+                    .setReplacingMessageId(wireMessage.replacingMessageId.toString())
                     .setText(
                         packText(
                             wireMessage = WireMessage.Text.create(
@@ -356,6 +356,7 @@ object ProtobufSerializer {
                             )
                         )
                     )
+                    .build()
             )
 
     private fun packReaction(


### PR DESCRIPTION
* Add additional parameter for replacingMessageId

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ 

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sending a TextEdited it would not update the original message (user had to change conversations and come back to see the updated value)

### Causes (Optional)

We were omitting the `replacingMessageId` and rather just sending the message id

### Solutions

Correctly send both message ID and `replacingMessageId`

### Testing

#### How to Test

- Have a conversation with an App
- from the App send a message
- then send a TextEdit message referencing the previous message id (sent from the bot)
- see that new text has been updated correctly
