### PR TITLE
feat: Add Conversation Type to Database #WPB-18243

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/ConversationData.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/ConversationData.kt
@@ -46,8 +46,6 @@ data class ConversationData(
                     ConversationResponse.Type.SELF -> SELF
                     ConversationResponse.Type.ONE_TO_ONE -> ONE_TO_ONE
                 }
-
-            fun toString(type: Type): String? = type.name
         }
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/ConversationData.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/ConversationData.kt
@@ -16,11 +16,38 @@
 package com.wire.integrations.jvm.model
 
 import com.wire.crypto.MLSGroupId
+import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
 
 @JvmRecord
 data class ConversationData(
     val id: QualifiedId,
     val name: String?,
     val teamId: TeamId?,
-    val mlsGroupId: MLSGroupId
-)
+    val mlsGroupId: MLSGroupId,
+    val type: Type
+) {
+    enum class Type {
+        GROUP,
+        SELF,
+        ONE_TO_ONE;
+
+        companion object {
+            fun fromString(value: String): Type =
+                when (value) {
+                    SELF.name -> SELF
+                    ONE_TO_ONE.name -> ONE_TO_ONE
+                    GROUP.name -> GROUP
+                    else -> GROUP
+                }
+
+            fun fromApi(value: ConversationResponse.Type): Type =
+                when (value) {
+                    ConversationResponse.Type.GROUP -> GROUP
+                    ConversationResponse.Type.SELF -> SELF
+                    ConversationResponse.Type.ONE_TO_ONE -> ONE_TO_ONE
+                }
+
+            fun toString(type: Type): String? = type.name
+        }
+    }
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/ConversationSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/ConversationSqlLiteStorage.kt
@@ -39,7 +39,8 @@ internal class ConversationSqlLiteStorage(db: AppsSdkDatabase) : ConversationSto
             domain = conversation.id.domain,
             name = conversation.name,
             mls_group_id = Base64.getEncoder().encodeToString(conversation.mlsGroupId.value),
-            team_id = conversation.teamId?.value?.toString()
+            team_id = conversation.teamId?.value?.toString(),
+            type = conversation.type.toString()
         )
     }
 
@@ -113,7 +114,8 @@ internal class ConversationSqlLiteStorage(db: AppsSdkDatabase) : ConversationSto
             id = QualifiedId(UUID.fromString(conv.id), conv.domain),
             name = conv.name,
             teamId = conv.team_id?.let { TeamId(UUID.fromString(it)) },
-            mlsGroupId = MLSGroupId(Base64.getDecoder().decode(conv.mls_group_id))
+            mlsGroupId = MLSGroupId(Base64.getDecoder().decode(conv.mls_group_id)),
+            type = ConversationData.Type.fromString(value = conv.type)
         )
 
     private fun conversationMemberMapper(member: Conversation_member) =

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/ConversationSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/ConversationSqlLiteStorage.kt
@@ -40,7 +40,7 @@ internal class ConversationSqlLiteStorage(db: AppsSdkDatabase) : ConversationSto
             name = conversation.name,
             mls_group_id = Base64.getEncoder().encodeToString(conversation.mlsGroupId.value),
             team_id = conversation.teamId?.value?.toString(),
-            type = conversation.type.toString()
+            type = conversation.type.name
         )
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -201,7 +201,8 @@ internal class EventsRouter internal constructor(
                 id = qualifiedConversation,
                 name = conversationName,
                 mlsGroupId = mlsGroupId,
-                teamId = conversation.teamId?.let { TeamId(it) }
+                teamId = conversation.teamId?.let { TeamId(it) },
+                type = ConversationData.Type.fromApi(value = conversation.type)
             )
         val members = conversation.members.others.map {
             ConversationMember(

--- a/lib/src/main/sqldelight/com/wire/integrations/jvm/Conversation.sq
+++ b/lib/src/main/sqldelight/com/wire/integrations/jvm/Conversation.sq
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS conversation (
   team_id TEXT,
   mls_group_id TEXT NOT NULL,
   creation_date TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  type TEXT NOT NULL,
   PRIMARY KEY (id, domain)
 );
 
@@ -18,9 +19,9 @@ FROM conversation
 WHERE id = ? AND domain = ?;
 
 insert:
-INSERT INTO conversation(id, domain, name, team_id, mls_group_id)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(id, domain) DO UPDATE SET name=excluded.name, team_id=excluded.team_id, mls_group_id=excluded.mls_group_id;
+INSERT INTO conversation(id, domain, name, team_id, mls_group_id, type)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(id, domain) DO UPDATE SET name=excluded.name, team_id=excluded.team_id, mls_group_id=excluded.mls_group_id, type=excluded.type;
 
 delete:
 DELETE FROM conversation

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsTest.kt
@@ -52,7 +52,8 @@ class WireEventsTest {
                     id = CONVERSATION_ID,
                     name = "Test conversation",
                     teamId = null,
-                    mlsGroupId = MLSGroupId(ByteArray(32) { 1 })
+                    mlsGroupId = MLSGroupId(ByteArray(32) { 1 }),
+                    type = ConversationData.Type.GROUP
                 ),
                 members = emptyList()
             )


### PR DESCRIPTION
* Add type field as string to Conversation.sq
* Adjusted mappers and database to accommodate new field
* Adjusted tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are not saving the Conversation Type to the database

### Causes (Optional)

We were retrieving from the API but never saving into the database.

### Solutions

Add new column `type` into `Conversation.sq`/Conversation table

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

### Notes (Optional)

Due to the SDK not being used in any production environment for now we decided on just adding the new field directly and not doing the migration in this ticket, but rather put out findings and implementations in a document in the Integrations Space for when the time comes for a new migration.
