### PR TITLE
feat: Register Proteus and MLS Clients #WPB-18796

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,6 +13,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+import java.util.UUID
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
@@ -196,5 +197,14 @@ tasks {
     }
     build {
         dependsOn(shadowJar)
+    }
+
+    /**
+     * Dummy environment variables for tests
+     */
+    test {
+        environment("WIRE_SDK_USER_ID", UUID.randomUUID().toString())
+        environment("WIRE_SDK_PASSWORD", "randomPassword")
+        environment("WIRE_SDK_ENVIRONMENT", "randomEnvironment")
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -25,6 +25,8 @@ import com.wire.integrations.jvm.model.http.ApiVersionResponse
 import com.wire.integrations.jvm.model.http.AppDataResponse
 import com.wire.integrations.jvm.model.http.FeaturesResponse
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
+import com.wire.integrations.jvm.model.http.client.RegisterClientRequest
+import com.wire.integrations.jvm.model.http.client.RegisterClientResponse
 import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
 import com.wire.integrations.jvm.model.http.user.UserResponse
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
@@ -44,6 +46,8 @@ interface BackendClient {
         appClientId: AppClientId,
         mlsPublicKeys: MlsPublicKeys
     )
+
+    suspend fun registerClient(registerClientRequest: RegisterClientRequest): RegisterClientResponse
 
     suspend fun uploadMlsKeyPackages(
         appClientId: AppClientId,

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
@@ -27,6 +27,8 @@ import com.wire.integrations.jvm.model.http.ApiVersionResponse
 import com.wire.integrations.jvm.model.http.AppDataResponse
 import com.wire.integrations.jvm.model.http.FeaturesResponse
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
+import com.wire.integrations.jvm.model.http.client.RegisterClientRequest
+import com.wire.integrations.jvm.model.http.client.RegisterClientResponse
 import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
 import com.wire.integrations.jvm.model.http.user.UserResponse
 import io.ktor.client.HttpClient
@@ -84,6 +86,12 @@ internal class BackendClientImpl(private val httpClient: HttpClient) : BackendCl
         appClientId: AppClientId,
         mlsPublicKeys: MlsPublicKeys
     ) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun registerClient(
+        registerClientRequest: RegisterClientRequest
+    ): RegisterClientResponse {
         TODO("Not yet implemented")
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
@@ -26,8 +26,6 @@ import com.wire.integrations.jvm.model.http.MlsPublicKeys
 import com.wire.integrations.jvm.model.http.client.PreKeyCrypto
 
 internal interface CryptoClient : AutoCloseable {
-    fun setAppClientId(appClientId: AppClientId)
-
     fun getAppClientId(): AppClientId?
 
     suspend fun encryptMls(
@@ -43,11 +41,11 @@ internal interface CryptoClient : AutoCloseable {
     /**
      * Proteus Configuration
      */
-    suspend fun createProteusClient()
+    suspend fun initializeProteusClient()
 
     suspend fun generateProteusPreKeys(
-        from: Int,
-        count: Int
+        from: Int = PROTEUS_PREKEYS_FROM_COUNT,
+        count: Int = PROTEUS_PREKEYS_MAX_COUNT
     ): ArrayList<PreKeyCrypto>
 
     suspend fun generateProteusLastPreKey(): PreKeyCrypto
@@ -99,5 +97,7 @@ internal interface CryptoClient : AutoCloseable {
 
     companion object {
         const val DEFAULT_KEYPACKAGE_COUNT = 100u
+        const val PROTEUS_PREKEYS_FROM_COUNT = 0
+        const val PROTEUS_PREKEYS_MAX_COUNT = 10
     }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CryptoClient.kt
@@ -19,12 +19,16 @@ package com.wire.integrations.jvm.crypto
 import com.wire.crypto.GroupInfo
 import com.wire.crypto.MLSGroupId
 import com.wire.crypto.MLSKeyPackage
+import com.wire.crypto.MlsTransport
 import com.wire.crypto.Welcome
 import com.wire.integrations.jvm.model.AppClientId
 import com.wire.integrations.jvm.model.http.MlsPublicKeys
+import com.wire.integrations.jvm.model.http.client.PreKeyCrypto
 
 internal interface CryptoClient : AutoCloseable {
-    fun getAppClientId(): AppClientId
+    fun setAppClientId(appClientId: AppClientId)
+
+    fun getAppClientId(): AppClientId?
 
     suspend fun encryptMls(
         mlsGroupId: MLSGroupId,
@@ -35,6 +39,26 @@ internal interface CryptoClient : AutoCloseable {
         mlsGroupId: MLSGroupId,
         encryptedMessage: String
     ): ByteArray?
+
+    /**
+     * Proteus Configuration
+     */
+    suspend fun createProteusClient()
+
+    suspend fun generateProteusPreKeys(
+        from: Int,
+        count: Int
+    ): ArrayList<PreKeyCrypto>
+
+    suspend fun generateProteusLastPreKey(): PreKeyCrypto
+
+    /**
+     * MLS Configuration
+     */
+    suspend fun initializeMlsClient(
+        appClientId: AppClientId,
+        mlsTransport: MlsTransport
+    )
 
     suspend fun mlsGetPublicKey(): MlsPublicKeys
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireException.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/exception/WireException.kt
@@ -17,6 +17,7 @@
 package com.wire.integrations.jvm.exception
 
 import com.wire.integrations.jvm.exception.NetworkErrorLabel.MLS_STALE_MESSAGE
+import com.wire.integrations.jvm.exception.NetworkErrorLabel.TOO_MANY_CLIENTS
 import com.wire.integrations.jvm.model.ErrorResponse
 
 /**
@@ -74,6 +75,11 @@ sealed class WireException @JvmOverloads constructor(
         val throwable: Throwable?
     ) : WireException(errorResponse.message) {
         fun isMlsStaleMessage(): Boolean = errorResponse.label == MLS_STALE_MESSAGE
+
+        /**
+         * Currently not used as we are not tackling yet the recovering for TooManyClients exception
+         */
+        fun isTooManyClients(): Boolean = errorResponse.label == TOO_MANY_CLIENTS
     }
 
     /**

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/AppClientId.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/AppClientId.kt
@@ -23,4 +23,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 value class AppClientId(val value: String) {
     override fun toString(): String = value.obfuscateClientId()
+
+    companion object {
+        fun create(
+            userId: String,
+            deviceId: String,
+            userDomain: String
+        ): AppClientId =
+            AppClientId(
+                value = "$userId:$deviceId@$userDomain"
+            )
+    }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/StandardError.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/StandardError.kt
@@ -27,5 +27,6 @@ data class StandardError(
     val message: String
 ) {
     fun isMlsStaleMessage(): Boolean = (label == MLS_STALE_MESSAGE)
+
     fun isTooManyClients(): Boolean = (label == TOO_MANY_CLIENTS)
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/StandardError.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/StandardError.kt
@@ -17,6 +17,7 @@
 package com.wire.integrations.jvm.model
 
 import com.wire.integrations.jvm.exception.NetworkErrorLabel.MLS_STALE_MESSAGE
+import com.wire.integrations.jvm.exception.NetworkErrorLabel.TOO_MANY_CLIENTS
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -26,4 +27,5 @@ data class StandardError(
     val message: String
 ) {
     fun isMlsStaleMessage(): Boolean = (label == MLS_STALE_MESSAGE)
+    fun isTooManyClients(): Boolean = (label == TOO_MANY_CLIENTS)
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/CapabilitiesRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/CapabilitiesRequest.kt
@@ -16,38 +16,14 @@
 
 package com.wire.integrations.jvm.model.http.client
 
-import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
-@Serializable(with = CapabilitiesRequestSerializer::class)
-enum class CapabilitiesRequest(val value: String) {
-    LEGALHOLD_IMPLICIT_CONSENT("legalhold-implicit-consent"),
-    CONSUMABLE_NOTIFICATIONS("consumable-notifications")
-}
+@Serializable
+enum class CapabilitiesRequest {
+    @SerialName("legalhold-implicit-consent")
+    LEGALHOLD_IMPLICIT_CONSENT,
 
-object CapabilitiesRequestSerializer : KSerializer<CapabilitiesRequest> {
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor(
-            "CapabilitiesRequest",
-            PrimitiveKind.STRING
-        )
-
-    override fun serialize(
-        encoder: Encoder,
-        value: CapabilitiesRequest
-    ) {
-        encoder.encodeString(value.value)
-    }
-
-    override fun deserialize(decoder: Decoder): CapabilitiesRequest {
-        val value = decoder.decodeString()
-        return CapabilitiesRequest.entries.find { it.value == value }
-            ?: throw SerializationException("Unknown capability: $value")
-    }
+    @SerialName("consumable-notifications")
+    CONSUMABLE_NOTIFICATIONS
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/CapabilitiesRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/CapabilitiesRequest.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.model.http.client
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = CapabilitiesRequestSerializer::class)
+enum class CapabilitiesRequest(val value: String) {
+    LEGALHOLD_IMPLICIT_CONSENT("legalhold-implicit-consent"),
+    CONSUMABLE_NOTIFICATIONS("consumable-notifications")
+}
+
+object CapabilitiesRequestSerializer : KSerializer<CapabilitiesRequest> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(
+            "CapabilitiesRequest",
+            PrimitiveKind.STRING
+        )
+
+    override fun serialize(
+        encoder: Encoder,
+        value: CapabilitiesRequest
+    ) {
+        encoder.encodeString(value.value)
+    }
+
+    override fun deserialize(decoder: Decoder): CapabilitiesRequest {
+        val value = decoder.decodeString()
+        return CapabilitiesRequest.entries.find { it.value == value }
+            ?: throw SerializationException("Unknown capability: $value")
+    }
+}

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/PreKeyCrypto.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/PreKeyCrypto.kt
@@ -14,9 +14,16 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.exception
+package com.wire.integrations.jvm.model.http.client
 
-internal object NetworkErrorLabel {
-    const val MLS_STALE_MESSAGE = "mls-stale-message"
-    const val TOO_MANY_CLIENTS = "too-many-clients"
-}
+import com.wire.crypto.PreKey
+import io.ktor.util.encodeBase64
+
+data class PreKeyCrypto(
+    val id: Int,
+    val encodedData: String
+)
+
+fun PreKeyCrypto.toApi(): PreKeyRequest = PreKeyRequest(id, encodedData)
+
+fun PreKey.toCryptography(): PreKeyCrypto = PreKeyCrypto(id.toInt(), data.encodeBase64())

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/PreKeyRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/PreKeyRequest.kt
@@ -14,9 +14,12 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.exception
+package com.wire.integrations.jvm.model.http.client
 
-internal object NetworkErrorLabel {
-    const val MLS_STALE_MESSAGE = "mls-stale-message"
-    const val TOO_MANY_CLIENTS = "too-many-clients"
-}
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PreKeyRequest(
+    val id: Int,
+    val key: String
+)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/RegisterClientRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/RegisterClientRequest.kt
@@ -14,9 +14,26 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.exception
+package com.wire.integrations.jvm.model.http.client
 
-internal object NetworkErrorLabel {
-    const val MLS_STALE_MESSAGE = "mls-stale-message"
-    const val TOO_MANY_CLIENTS = "too-many-clients"
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterClientRequest(
+    val password: String,
+    val type: String = "permanent",
+    val model: String = "App Client",
+    @SerialName("lastkey")
+    val lastKey: PreKeyRequest,
+    @SerialName("prekeys")
+    val preKeys: List<PreKeyRequest>,
+    val capabilities: List<CapabilitiesRequest>
+) {
+    companion object {
+        val DEFAULT_CAPABILITIES = listOf<CapabilitiesRequest>(
+            CapabilitiesRequest.LEGALHOLD_IMPLICIT_CONSENT,
+            CapabilitiesRequest.CONSUMABLE_NOTIFICATIONS
+        )
+    }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/RegisterClientResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/client/RegisterClientResponse.kt
@@ -14,9 +14,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.exception
+package com.wire.integrations.jvm.model.http.client
 
-internal object NetworkErrorLabel {
-    const val MLS_STALE_MESSAGE = "mls-stale-message"
-    const val TOO_MANY_CLIENTS = "too-many-clients"
-}
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterClientResponse(val id: String)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
@@ -22,6 +22,7 @@ import com.wire.integrations.jvm.AppsSdkDatabase
 import com.wire.integrations.jvm.model.AppClientId
 import com.wire.integrations.jvm.model.AppData
 
+private const val DEVICE_ID = "device_id"
 private const val CLIENT_ID = "client_id"
 
 class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
@@ -47,6 +48,10 @@ class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
         runCatching { AppClientId(getById(CLIENT_ID).value) }.getOrNull()
 
     override fun saveClientId(appClientId: String) = save(CLIENT_ID, appClientId)
+
+    override fun getDeviceId(): String? = runCatching { getById(DEVICE_ID).value }.getOrNull()
+
+    override fun saveDeviceId(deviceId: String) = save(DEVICE_ID, deviceId)
 
     private fun appMapper(app: App) =
         AppData(

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
@@ -19,11 +19,9 @@ package com.wire.integrations.jvm.persistence
 import com.wire.integrations.jvm.App
 import com.wire.integrations.jvm.AppQueries
 import com.wire.integrations.jvm.AppsSdkDatabase
-import com.wire.integrations.jvm.model.AppClientId
 import com.wire.integrations.jvm.model.AppData
 
 private const val DEVICE_ID = "device_id"
-private const val CLIENT_ID = "client_id"
 
 class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
     private val appQueries: AppQueries = db.appQueries
@@ -43,11 +41,6 @@ class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
 
     override fun getById(key: String): AppData =
         appQueries.selectByKey(key).executeAsOne().let { appMapper(it) }
-
-    override fun getClientId(): AppClientId? =
-        runCatching { AppClientId(getById(CLIENT_ID).value) }.getOrNull()
-
-    override fun saveClientId(appClientId: String) = save(CLIENT_ID, appClientId)
 
     override fun getDeviceId(): String? = runCatching { getById(DEVICE_ID).value }.getOrNull()
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppStorage.kt
@@ -34,4 +34,8 @@ interface AppStorage {
     fun getClientId(): AppClientId?
 
     fun saveClientId(appClientId: String)
+
+    fun getDeviceId(): String?
+
+    fun saveDeviceId(deviceId: String)
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppStorage.kt
@@ -15,7 +15,6 @@
 
 package com.wire.integrations.jvm.persistence
 
-import com.wire.integrations.jvm.model.AppClientId
 import com.wire.integrations.jvm.model.AppData
 
 interface AppStorage {
@@ -30,10 +29,6 @@ interface AppStorage {
     fun getAll(): List<AppData>
 
     fun getById(key: String): AppData
-
-    fun getClientId(): AppClientId?
-
-    fun saveClientId(appClientId: String)
 
     fun getDeviceId(): String?
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -218,10 +218,12 @@ internal class EventsRouter internal constructor(
         conversationStorage.saveMembers(qualifiedConversation, members)
 
         if (cryptoClient.hasTooFewKeyPackageCount()) {
-            backendClient.uploadMlsKeyPackages(
-                appClientId = cryptoClient.getAppClientId(),
-                mlsKeyPackages = cryptoClient.mlsGenerateKeyPackages().map { it.value }
-            )
+            cryptoClient.getAppClientId()?.let { appClientId ->
+                backendClient.uploadMlsKeyPackages(
+                    appClientId = appClientId,
+                    mlsKeyPackages = cryptoClient.mlsGenerateKeyPackages().map { it.value }
+                )
+            }
         }
 
         groupId?.run {

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
@@ -61,7 +61,12 @@ object TestUtils {
                         "expires_in" : 3600
                     }
                     """.trimIndent()
-                ).withHeaders(HttpHeaders(HttpHeader("set-cookie", "zuid=demoCookie")))
+                ).withHeaders(
+                    HttpHeaders(
+                        HttpHeader("set-cookie", "zuid=demoCookie"),
+                        HttpHeader("Content-Type", "application/json")
+                    )
+                )
             )
         )
         wireMockServer.stubFor(

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
@@ -1,0 +1,187 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.utils
+
+import com.wire.crypto.Ciphersuite
+import com.wire.crypto.CoreCrypto
+import com.wire.crypto.CoreCryptoException
+import com.wire.crypto.DatabaseKey
+import com.wire.crypto.GroupInfo
+import com.wire.crypto.MLSGroupId
+import com.wire.crypto.MLSKeyPackage
+import com.wire.crypto.MlsException
+import com.wire.crypto.MlsTransport
+import com.wire.crypto.Welcome
+import com.wire.integrations.jvm.config.IsolatedKoinContext
+import com.wire.integrations.jvm.crypto.CryptoClient
+import com.wire.integrations.jvm.exception.WireException.InvalidParameter
+import com.wire.integrations.jvm.model.AppClientId
+import com.wire.integrations.jvm.model.http.MlsPublicKeys
+import com.wire.integrations.jvm.model.http.client.PreKeyCrypto
+import com.wire.integrations.protobuf.messages.Messages
+import com.wire.integrations.protobuf.messages.Messages.GenericMessage
+import java.io.File
+import java.util.UUID
+
+internal class MockCoreCryptoClient private constructor(
+    private val ciphersuite: Ciphersuite,
+    private var coreCrypto: CoreCrypto
+) : CryptoClient {
+    val conversationExist = mutableSetOf<MLSGroupId>()
+    private var _appClientId: AppClientId? = null
+
+    override fun setAppClientId(appClientId: AppClientId) {
+        _appClientId = appClientId
+    }
+
+    override fun getAppClientId(): AppClientId? = _appClientId
+
+    override suspend fun createProteusClient() {
+        // Do nothing
+    }
+
+    override suspend fun generateProteusPreKeys(
+        from: Int,
+        count: Int
+    ): ArrayList<PreKeyCrypto> {
+        val preKeys = arrayListOf<PreKeyCrypto>()
+        for (i in from..count) {
+            preKeys.add(
+                PreKeyCrypto(
+                    id = i,
+                    encodedData = "encoded_data_$i"
+                )
+            )
+        }
+
+        return preKeys
+    }
+
+    override suspend fun generateProteusLastPreKey(): PreKeyCrypto =
+        PreKeyCrypto(
+            id = 0,
+            encodedData = "encoded_data_last_key"
+        )
+
+    override suspend fun initializeMlsClient(
+        appClientId: AppClientId,
+        mlsTransport: MlsTransport
+    ) {
+        // Do nothing
+    }
+
+    override suspend fun decryptMls(
+        mlsGroupId: MLSGroupId,
+        encryptedMessage: String
+    ): ByteArray = GENERIC_TEXT_MESSAGE.toByteArray()
+
+    // Throw OrphanWelcome, testing the fallback to createJoinMlsConversationRequest
+    override suspend fun processWelcomeMessage(welcome: Welcome): MLSGroupId =
+        throw CoreCryptoException.Mls(MlsException.OrphanWelcome())
+
+    // Mock joining the conversation, assume the backend accepts the invitation
+    override suspend fun joinMlsConversationRequest(groupInfo: GroupInfo): MLSGroupId = MLS_GROUP_ID
+
+    override suspend fun encryptMls(
+        mlsGroupId: MLSGroupId,
+        message: ByteArray
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun mlsGetPublicKey(): MlsPublicKeys {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun mlsGenerateKeyPackages(packageCount: UInt): List<MLSKeyPackage> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun hasTooFewKeyPackageCount(): Boolean = false
+
+    override fun close() {
+        // Do nothing
+    }
+
+    override suspend fun createConversation(groupId: MLSGroupId) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun addMemberToMlsConversation(
+        mlsGroupId: MLSGroupId,
+        keyPackages: List<MLSKeyPackage>
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun conversationExists(mlsGroupId: MLSGroupId): Boolean {
+        val wasConversationAdded = conversationExist.add(mlsGroupId)
+        return !wasConversationAdded
+    }
+
+    override suspend fun conversationEpoch(mlsGroupId: MLSGroupId): ULong = 0UL
+
+    companion object {
+        suspend fun create(
+            userId: String,
+            ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER
+        ): MockCoreCryptoClient {
+            val clientDirectoryPath = "cryptography/$userId"
+            val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
+            val ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
+
+            File(clientDirectoryPath).mkdirs()
+
+            val coreCrypto = CoreCrypto.invoke(
+                keystore = keystorePath,
+                databaseKey = IsolatedKoinContext.getCryptographyStoragePassword()
+                    ?.let { DatabaseKey(it) }
+                    ?: throw InvalidParameter("Cryptography password missing")
+            )
+
+            return MockCoreCryptoClient(
+                ciphersuite = ciphersuite,
+                coreCrypto = coreCrypto
+            )
+        }
+
+        private fun getMlsCipherSuiteName(code: Int): Ciphersuite =
+            when (code) {
+                DEFAULT_CIPHERSUITE_IDENTIFIER -> Ciphersuite.DEFAULT
+                2 -> Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+                3 -> Ciphersuite.MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
+                4 -> Ciphersuite.MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
+                5 -> Ciphersuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
+                6 -> Ciphersuite.MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
+                7 -> Ciphersuite.MLS_256_DHKEMP384_AES256GCM_SHA384_P384
+                else -> Ciphersuite.DEFAULT
+            }
+
+        private const val DEFAULT_CIPHERSUITE_IDENTIFIER = 1
+        private const val KEYSTORE_NAME = "keystore"
+        val MLS_GROUP_ID = MLSGroupId(UUID.randomUUID().toString().toByteArray())
+        val GENERIC_TEXT_MESSAGE: GenericMessage = GenericMessage
+            .newBuilder()
+            .setMessageId(UUID.randomUUID().toString())
+            .setText(
+                Messages.Text.newBuilder()
+                    .setContent("Decrypted message content")
+                    .build()
+            )
+            .build()
+    }
+}

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
@@ -42,15 +42,15 @@ internal class MockCoreCryptoClient private constructor(
     private var coreCrypto: CoreCrypto
 ) : CryptoClient {
     val conversationExist = mutableSetOf<MLSGroupId>()
-    private var _appClientId: AppClientId? = null
+    private var appClientId: AppClientId? = null
 
-    override fun setAppClientId(appClientId: AppClientId) {
-        _appClientId = appClientId
+    fun setAppClientId(appClientId: AppClientId) {
+        this.appClientId = appClientId
     }
 
-    override fun getAppClientId(): AppClientId? = _appClientId
+    override fun getAppClientId(): AppClientId? = appClientId
 
-    override suspend fun createProteusClient() {
+    override suspend fun initializeProteusClient() {
         // Do nothing
     }
 


### PR DESCRIPTION
* Add API call to RegisterClient (and its Request and Response data classes)
* Add get/save of DeviceId (different from AppClientId)
* Add return of demo loginUser method based on retrieved DeviceId
* Add NetworkErrorLabel for when there are TooManyClients exception when registering a new client althought not handled.
* Add main logic for registering Proteus client and its PreKeys.
* Adjust tests
* Add dummy environment test variables

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When using the SDK there was the need to manually register a Proteus client through cURL to use its ID.

### Causes (Optional)

We weren't handling the Proteus client initialization through the SDK but rather only MLS.

### Solutions

- When starting the SDK, verify if there is an existing client, if so continue with initiliazing MLS client.
- Otherwise create a Proteus Client and use its ID to initialize a MLS Client.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Run the SDK
- Everything should be as before, but now no need to pass a Client ID from the environment variables.