### PR TITLE
chore: Move default env from Chala to Staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ Thumbs.db
 
 # Allow automatic IntelliJ's automatic copyright
 !.idea/copyright/**
-**/demo.properties

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ For licensing information, see the attached LICENSE file and the list of third-p
 
 If you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and cause that application to connect to our servers for any purposes, we refer to that resulting application as an “Open Source App”.  All Open Source Apps are subject to, and may only be used and/or commercialized in accordance with, the Terms of Use applicable to the Wire Application, which can be found at https://wire.com/legal/#terms.  Additionally, if you choose to build an Open Source App, certain restrictions apply, as follows:
 
-a. You agree not to change the way the Open Source App connects and interacts with our servers; b. You agree not to weaken any of the security features of the Open Source App; c. You agree not to use our servers to store data for purposes other than the intended and original functionality of the Open Source App; d. You acknowledge that you are solely responsible for any and all updates to your Open Source App.
+a. You agree not to change the way the Open Source App connects and interacts with our servers;
+
+b. You agree not to weaken any of the security features of the Open Source App;
+
+c. You agree not to use our servers to store data for purposes other than the intended and original functionality of the Open Source App;
+
+d. You acknowledge that you are solely responsible for any and all updates to your Open Source App.
 
 For clarity, if you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and do not cause that application to connect to our servers for any purposes, then that application will not be deemed an Open Source App and the foregoing will not apply to that application.
 
@@ -40,6 +46,7 @@ For information about usage and onboarding refer to [Sdk tutorial](docs/APPLICAT
 * Access to the file system to store cryptographic keys and data
 
 ## Import with
+The latest release is avaliable at [Maven Central](https://central.sonatype.com/artifact/com.wire/wire-apps-jvm-sdk).
 
 ### Gradle
 
@@ -51,7 +58,7 @@ dependencies {
 
 ### Maven
 ```xml
-<dependency>
+<dependency>persistence
     <groupId>com.wire</groupId>
     <artifactId>wire-apps-jvm-sdk</artifactId>
     <version>0.0.1</version>
@@ -63,7 +70,6 @@ dependencies {
 WIRE_SDK_USER_ID=abcd-1234-efgh-5678
 WIRE_SDK_EMAIL=your_email@domain.com
 WIRE_SDK_PASSWORD=randomPassword
-WIRE_SDK_CLIENT=dd228f6343d3916
 WIRE_SDK_ENVIRONMENT=my.domain.link
 ```
 
@@ -86,6 +92,3 @@ You can define the implementation of BackendClient to use, by changing it in the
   testing instead of the Application API and also some environment variables specified above.
 * BackendClientImpl is the real implementation of the SDK, targeting the Wire backend as an
   Application
-
-For the demo setup, some default properties are there, you can override those values
-by creating a `demo.properties` file in the classpath (e.g. `src/main/resources/demo.properties`).

--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -113,7 +113,7 @@ class MyWireEventsHandler : WireEventsHandler() {
 }
 ```
 
-**NOTE**: Your application can simply call `startListening()` and a new thread is created and will keep the Application running and receiving events. To stop it, just close the Application (Cmd+d) or call `stopListening()`
+**NOTE**: Your application can simply call `startListening()` and a new thread is created and will keep the Application running and receiving events. To stop it, just close the Application (Ctrl+C/Cmd+C) or call `stopListening()`
 
 ## Sending Messages
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientDemo.kt
@@ -444,7 +444,7 @@ internal class BackendClientDemo(
             System.getenv("WIRE_SDK_PASSWORD") ?: "Aqa123456!"
 
         val DEMO_ENVIRONMENT: String =
-            System.getenv("WIRE_SDK_ENVIRONMENT") ?: "chala.wire.link"
+            System.getenv("WIRE_SDK_ENVIRONMENT") ?: "staging.zinfra.io"
     }
 }
 

--- a/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
+++ b/sample/src/main/kotlin/com/wire/integrations/sample/Main.kt
@@ -45,7 +45,7 @@ fun main() {
         id = UUID.fromString("2afce87f-3195-4c51-9e7c-3b01faf13ac5"),
         domain = "staging.zinfra.io"
     )
-     logger.info(applicationManager.getUser(selfUser).toString())
+    logger.info(applicationManager.getUser(selfUser).toString())
     logger.info("Wire backend domain: ${applicationManager.getBackendConfiguration().domain}")
 
     // Use wireAppSdk.stop() to stop the SDK or just stop it with Ctrl+C/Cmd+C


### PR DESCRIPTION
- Documentation refactorings and typo fix after Baris feedback

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SDK still referenced Chala env and had some typos

### Solutions

Move default to Staging and fix typos

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
