### PR TITLE
chore: Create 'storage' directory WPB-19493

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build
 cryptography
 lib/cryptography
 
+# Ignore Storage directory
+storage
+
 # Ignore IntelliJ IDEA project files
 .idea
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ build
 cryptography
 lib/cryptography
 
-# Ignore Storage directory
-storage
+# Ignore Storage directory content but keep the directory
+storage/*
+!storage/.gitkeep
 
 # Ignore IntelliJ IDEA project files
 .idea

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ WIRE_SDK_ENVIRONMENT=my.domain.link
 ## Troubleshooting
 
 If you have started using the SDK targeting one Wire environment,
-and later you want to switch to another, you may need to move/delete the `apps.db` directory
+and later you want to switch to another, you may need to move/delete the `storage/apps.db` directory
 
 ### Testing the SDK
 

--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -270,7 +270,7 @@ In case you need to build the SDK locally, you can skip the signing option by ru
 ## Troubleshooting
 
 - Enable DEBUG logging on the SDK if you are developing an Application and want to test it in a safe environment. Set the log level to DEBUG in your logging framework for the package `com.wire.integrations.jvm` (e.g. for Logback `<logger name="com.wire.integrations.jvm" level="DEBUG" />`).
-- If you switch between different Wire environments, you may need to delete the `apps.db` directory to avoid conflicts
+- If you switch between different Wire environments, you may need to delete the `storage/apps.db` directory to avoid conflicts
 - For connection issues, verify your API token, host URL and if your deployed app has access to the public network (firewalls, docker ports, etc.)
 - When running into cryptography issues, ensure your storage password is consistent between app restarts
 - The SDK is designed to be thread-safe. The `startListening()` and `stopListening()` methods are synchronized to prevent concurrent modifications to the SDK state. However at this moment, only using a single Wire Application instance has been tested.

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/crypto/CoreCryptoClient.kt
@@ -215,7 +215,7 @@ internal class CoreCryptoClient private constructor(
             userId: String,
             ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER
         ): CoreCryptoClient {
-            val clientDirectoryPath = "cryptography/$userId"
+            val clientDirectoryPath = "storage/cryptography/$userId"
             val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
             val ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
 

--- a/lib/src/main/resources/koin-sdk.properties
+++ b/lib/src/main/resources/koin-sdk.properties
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
-database-jdbc-url=jdbc:sqlite:apps.db
+database-jdbc-url=jdbc:sqlite:storage/apps.db

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/utils/MockCoreCryptoClient.kt
@@ -149,7 +149,7 @@ internal class MockCoreCryptoClient private constructor(
             userId: String,
             ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER
         ): MockCoreCryptoClient {
-            val clientDirectoryPath = "cryptography/$userId"
+            val clientDirectoryPath = "storage/cryptography/$userId"
             val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
             val ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
 


### PR DESCRIPTION
Create 'storage' folder on the root level
Update the location of 'app.db' from root to 'storage'
Update the location of 'cryptography' directory from root to 'storage'
Update documentations accordingly

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The location of 'cryptography' folder and the 'apps.db' was causing problems on dockerization on the way to Kubernetes.

### Solutions

We changed the location of cryptography' folder and the 'apps.db' and moved into a new folder called 'storage' to enable volume creation. 
