### PR TITLE
feat: Re-join existing MLS conversations #WPB-19401

### DIFF
--- a/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/WireAppSdk.kt
@@ -18,6 +18,7 @@ package com.wire.integrations.jvm
 import com.wire.integrations.jvm.config.IsolatedKoinContext
 import com.wire.integrations.jvm.service.WireApplicationManager
 import com.wire.integrations.jvm.service.WireTeamEventsListener
+import com.wire.integrations.jvm.service.conversation.ConversationService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.koin.dsl.module
@@ -70,6 +71,11 @@ class WireAppSdk(
                 }
                 logger.info("Connection ended, attempting to reconnect...")
             }
+        }
+
+        runBlocking {
+            val conversationService = IsolatedKoinContext.koinApp.koin.get<ConversationService>()
+            conversationService.establishOrRejoinConversations()
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClient.kt
@@ -96,6 +96,12 @@ interface BackendClient {
 
     suspend fun getOneToOneConversation(userId: QualifiedId): OneToOneConversationResponse
 
+    suspend fun getConversationIds(): List<QualifiedId>
+
+    suspend fun getConversationFromIds(
+        conversationIds: List<QualifiedId>
+    ): List<ConversationResponse>
+
     companion object {
         const val API_VERSION = "v10"
     }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/client/BackendClientImpl.kt
@@ -167,4 +167,14 @@ internal class BackendClientImpl(private val httpClient: HttpClient) : BackendCl
     ): OneToOneConversationResponse {
         TODO("Not yet implemented")
     }
+
+    override suspend fun getConversationIds(): List<QualifiedId> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getConversationFromIds(
+        conversationIds: List<QualifiedId>
+    ): List<ConversationResponse> {
+        TODO("Not yet implemented")
+    }
 }

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/config/Modules.kt
@@ -94,7 +94,7 @@ val sdkModule =
         single { WireTeamEventsListener(get(), get()) }
 
         // Services
-        single { ConversationService(get(), get()) }
+        single { ConversationService(get(), get(), get(), get()) }
 
         // Manager
         single { WireApplicationManager(get(), get(), get(), get(), get(), get()) }
@@ -182,6 +182,7 @@ internal suspend fun getOrInitCryptoClient(
             appClientId = appClientId,
             mlsTransport = mlsTransport
         )
+        appStorage.setShouldRejoinConversations(should = false)
     } else {
         val userPassword = System.getenv("WIRE_SDK_PASSWORD")
         requireNotNull(userPassword)
@@ -235,6 +236,8 @@ internal suspend fun getOrInitCryptoClient(
             appClientId = appClientId,
             mlsKeyPackages = cryptoClient.mlsGenerateKeyPackages().map { it.value.copyBytes() }
         )
+
+        appStorage.setShouldRejoinConversations(should = true)
     }
 
     return cryptoClient

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListIdsRequest.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListIdsRequest.kt
@@ -1,6 +1,7 @@
 /*
  * Wire
  * Copyright (C) 2025 Wire Swiss GmbH
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,28 +14,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.persistence
+package com.wire.integrations.jvm.model.http.conversation
 
-import com.wire.integrations.jvm.model.AppData
+import com.wire.integrations.jvm.model.QualifiedId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-interface AppStorage {
-    /**
-     * Save (UPSERT) a key-value pair representing a property.
-     */
-    fun save(
-        key: String,
-        value: String
-    )
-
-    fun getAll(): List<AppData>
-
-    fun getByKey(key: String): AppData
-
-    fun getDeviceId(): String?
-
-    fun saveDeviceId(deviceId: String)
-
-    fun getShouldRejoinConversations(): Boolean?
-
-    fun setShouldRejoinConversations(should: Boolean)
-}
+@Serializable
+data class ConversationListIdsRequest(
+    @SerialName("qualified_ids")
+    val qualifiedIds: List<QualifiedId>
+)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListIdsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListIdsResponse.kt
@@ -1,6 +1,7 @@
 /*
  * Wire
  * Copyright (C) 2025 Wire Swiss GmbH
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,28 +14,18 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.persistence
+package com.wire.integrations.jvm.model.http.conversation
 
-import com.wire.integrations.jvm.model.AppData
+import com.wire.integrations.jvm.model.QualifiedId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-interface AppStorage {
-    /**
-     * Save (UPSERT) a key-value pair representing a property.
-     */
-    fun save(
-        key: String,
-        value: String
-    )
-
-    fun getAll(): List<AppData>
-
-    fun getByKey(key: String): AppData
-
-    fun getDeviceId(): String?
-
-    fun saveDeviceId(deviceId: String)
-
-    fun getShouldRejoinConversations(): Boolean?
-
-    fun setShouldRejoinConversations(should: Boolean)
-}
+@Serializable
+data class ConversationListIdsResponse(
+    @SerialName("has_more")
+    val hasMore: Boolean,
+    @SerialName("paging_state")
+    val pagingState: String,
+    @SerialName("qualified_conversations")
+    val qualifiedConversations: List<QualifiedId>
+)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListPaginationConfig.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationListPaginationConfig.kt
@@ -1,6 +1,7 @@
 /*
  * Wire
  * Copyright (C) 2025 Wire Swiss GmbH
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,28 +14,15 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.persistence
+package com.wire.integrations.jvm.model.http.conversation
 
-import com.wire.integrations.jvm.model.AppData
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-interface AppStorage {
-    /**
-     * Save (UPSERT) a key-value pair representing a property.
-     */
-    fun save(
-        key: String,
-        value: String
-    )
-
-    fun getAll(): List<AppData>
-
-    fun getByKey(key: String): AppData
-
-    fun getDeviceId(): String?
-
-    fun saveDeviceId(deviceId: String)
-
-    fun getShouldRejoinConversations(): Boolean?
-
-    fun setShouldRejoinConversations(should: Boolean)
-}
+@Serializable
+data class ConversationListPaginationConfig(
+    @SerialName("paging_state")
+    val pagingState: String?,
+    @SerialName("size")
+    val size: Int
+)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationResponse.kt
@@ -18,6 +18,8 @@ package com.wire.integrations.jvm.model.http.conversation
 
 import com.wire.crypto.MLSGroupId
 import com.wire.crypto.toGroupId
+import com.wire.integrations.jvm.exception.WireException
+import com.wire.integrations.jvm.model.CryptoProtocol
 import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.integrations.jvm.utils.UUIDSerializer
 import io.ktor.util.decodeBase64Bytes
@@ -33,11 +35,13 @@ data class ConversationResponse(
     @SerialName("team")
     val teamId: UUID?,
     @SerialName("group_id")
-    val groupId: String,
+    val groupId: String?,
     @SerialName("name")
     val name: String?,
     @SerialName("epoch")
-    val epoch: Long,
+    val epoch: Long?,
+    @SerialName("protocol")
+    val protocol: CryptoProtocol,
     @SerialName("members")
     val members: ConversationMembers,
     @SerialName("type")
@@ -59,7 +63,8 @@ data class ConversationResponse(
 }
 
 fun ConversationResponse.getDecodedMlsGroupId(): MLSGroupId =
-    this.groupId.decodeBase64Bytes().toGroupId()
+    this.groupId?.decodeBase64Bytes()?.toGroupId()
+        ?: throw WireException.MissingParameter("MLSGroupId should not be empty or null.")
 
 @Serializable
 data class OneToOneConversationResponse(

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/model/http/conversation/ConversationsResponse.kt
@@ -1,6 +1,7 @@
 /*
  * Wire
  * Copyright (C) 2025 Wire Swiss GmbH
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,28 +14,18 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.integrations.jvm.persistence
+package com.wire.integrations.jvm.model.http.conversation
 
-import com.wire.integrations.jvm.model.AppData
+import com.wire.integrations.jvm.model.QualifiedId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-interface AppStorage {
-    /**
-     * Save (UPSERT) a key-value pair representing a property.
-     */
-    fun save(
-        key: String,
-        value: String
-    )
-
-    fun getAll(): List<AppData>
-
-    fun getByKey(key: String): AppData
-
-    fun getDeviceId(): String?
-
-    fun saveDeviceId(deviceId: String)
-
-    fun getShouldRejoinConversations(): Boolean?
-
-    fun setShouldRejoinConversations(should: Boolean)
-}
+@Serializable
+data class ConversationsResponse(
+    @SerialName("failed")
+    val failed: List<QualifiedId>,
+    @SerialName("not_found")
+    val notFound: List<QualifiedId>,
+    @SerialName("found")
+    val found: List<ConversationResponse>
+)

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/persistence/AppSqlLiteStorage.kt
@@ -22,6 +22,7 @@ import com.wire.integrations.jvm.AppsSdkDatabase
 import com.wire.integrations.jvm.model.AppData
 
 private const val DEVICE_ID = "device_id"
+private const val SHOULD_REJOIN_CONVERSATIONS = "should_rejoin_conversations"
 
 class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
     private val appQueries: AppQueries = db.appQueries
@@ -39,12 +40,20 @@ class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
     override fun getAll(): List<AppData> =
         appQueries.selectAll().executeAsList().map { appMapper(it) }
 
-    override fun getById(key: String): AppData =
+    override fun getByKey(key: String): AppData =
         appQueries.selectByKey(key).executeAsOne().let { appMapper(it) }
 
-    override fun getDeviceId(): String? = runCatching { getById(DEVICE_ID).value }.getOrNull()
+    override fun getDeviceId(): String? = runCatching { getByKey(DEVICE_ID).value }.getOrNull()
 
     override fun saveDeviceId(deviceId: String) = save(DEVICE_ID, deviceId)
+
+    override fun getShouldRejoinConversations(): Boolean? =
+        runCatching {
+            getByKey(SHOULD_REJOIN_CONVERSATIONS).value.toBoolean()
+        }.getOrNull()
+
+    override fun setShouldRejoinConversations(should: Boolean) =
+        save(SHOULD_REJOIN_CONVERSATIONS, should.toString())
 
     private fun appMapper(app: App) =
         AppData(

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/EventsRouter.kt
@@ -20,7 +20,6 @@ import com.wire.crypto.CoreCryptoException
 import com.wire.crypto.MLSGroupId
 import com.wire.crypto.MlsException
 import com.wire.crypto.Welcome
-import com.wire.crypto.toGroupId
 import com.wire.crypto.toGroupInfo
 import com.wire.crypto.toWelcome
 import com.wire.integrations.jvm.WireEventsHandler
@@ -37,6 +36,7 @@ import com.wire.integrations.jvm.model.WireMessage
 import com.wire.integrations.jvm.model.http.EventContentDTO
 import com.wire.integrations.jvm.model.http.EventResponse
 import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
+import com.wire.integrations.jvm.model.http.conversation.getDecodedMlsGroupId
 import com.wire.integrations.jvm.model.protobuf.ProtobufDeserializer
 import com.wire.integrations.jvm.persistence.ConversationStorage
 import com.wire.integrations.jvm.persistence.TeamStorage
@@ -191,10 +191,7 @@ internal class EventsRouter internal constructor(
         groupId: MLSGroupId?
     ): MLSGroupId {
         val conversation = backendClient.getConversation(qualifiedConversation)
-        val mlsGroupId = groupId ?: Base64
-            .getDecoder()
-            .decode(conversation.groupId)
-            .toGroupId()
+        val mlsGroupId = groupId ?: conversation.getDecodedMlsGroupId()
 
         val conversationName = if (conversation.type == ConversationResponse.Type.ONE_TO_ONE) {
             backendClient.getUserData(userId = conversation.members.others.first().id).name

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategy.kt
@@ -45,7 +45,9 @@ class MlsFallbackStrategy internal constructor(
     ) {
         val conversationExists = cryptoClient.conversationExists(mlsGroupId = mlsGroupId)
         val fetchedConversation = backendClient.getConversation(conversationId = conversationId)
+        val conversationEpoch = fetchedConversation.epoch
         val currentEpoch = cryptoClient.conversationEpoch(mlsGroupId = mlsGroupId)
+        val isEpochBehind = conversationEpoch != null && currentEpoch.toLong() < conversationEpoch
 
         logger.info(
             "Verifying Fallback Strategy for conversationId: $conversationId, " +
@@ -53,7 +55,7 @@ class MlsFallbackStrategy internal constructor(
                 "epoch: local[$currentEpoch] < remote[${fetchedConversation.epoch}]"
         )
 
-        if (!conversationExists || currentEpoch.toLong() < fetchedConversation.epoch) {
+        if (!conversationExists || isEpochBehind) {
             val groupInfo = backendClient.getConversationGroupInfo(
                 conversationId = conversationId
             )

--- a/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/integrations/jvm/service/WireApplicationManager.kt
@@ -63,7 +63,7 @@ class WireApplicationManager internal constructor(
     fun getStoredConversations(): List<ConversationData> = conversationStorage.getAll()
 
     fun getStoredConversationMembers(conversationId: QualifiedId): List<ConversationMember> =
-        conversationStorage.getMembersByConversationId(conversationId)
+        conversationService.getStoredConversationMembers(conversationId = conversationId)
 
     /**
      * Get API configuration from the connected Wire backend.

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/TestUtils.kt
@@ -129,6 +129,23 @@ object TestUtils {
                 WireMock.ok()
             )
         )
+        wireMockServer.stubFor(
+            WireMock.post(
+                WireMock.urlPathTemplate(
+                    "/$V/conversations/list-ids"
+                )
+            ).willReturn(
+                WireMock.okJson(
+                    """
+                        {
+                            "has_more": false,
+                            "paging_state": "123",
+                            "qualified_conversations": []
+                        }
+                    """.trimIndent()
+                )
+            )
+        )
     }
 
     fun setupSdk(eventsHandler: WireEventsHandler) {

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/MlsFallbackStrategyTest.kt
@@ -20,6 +20,7 @@ import com.wire.crypto.toGroupId
 import com.wire.crypto.toGroupInfo
 import com.wire.integrations.jvm.client.BackendClientDemo
 import com.wire.integrations.jvm.crypto.CryptoClient
+import com.wire.integrations.jvm.model.CryptoProtocol
 import com.wire.integrations.jvm.model.QualifiedId
 import com.wire.integrations.jvm.model.TeamId
 import com.wire.integrations.jvm.model.http.conversation.ConversationMembers
@@ -161,7 +162,8 @@ class MlsFallbackStrategyTest {
             name = "Random Conversation",
             epoch = 0L,
             members = ConversationMembers(others = emptyList()),
-            type = ConversationResponse.Type.GROUP
+            type = ConversationResponse.Type.GROUP,
+            protocol = CryptoProtocol.MLS
         )
     }
 }

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireApplicationManagerTest.kt
@@ -278,6 +278,7 @@ class WireApplicationManagerTest {
                 "group_id": "$GROUP_CONVERSATION_MLS_GROUP_ID_BASE64",
                 "team": "${TEAM_ID.value}",
                 "type": 0
+                "protocol": "mls"
             }
             """.trimIndent()
 
@@ -295,7 +296,8 @@ class WireApplicationManagerTest {
                 },
                 "group_id": "$CHANNEL_CONVERSATION_MLS_GROUP_ID_BASE64",
                 "team": "${TEAM_ID.value}",
-                "type": 0
+                "type": 0,
+                "protocol": "mls"
             }
             """.trimIndent()
 
@@ -314,7 +316,8 @@ class WireApplicationManagerTest {
                     },
                     "group_id": "$ONE_TO_ONE_CONVERSATION_MLS_GROUP_ID_BASE64",
                     "team": "${TEAM_ID.value}",
-                    "type": 1
+                    "type": 1,
+                    "protocol": "mls"
                 },
                 "public_keys": {
                     "removal": {

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/WireEventsIntegrationTest.kt
@@ -371,7 +371,8 @@ class WireEventsIntegrationTest {
                     },
                     "group_id": "$MLS_GROUP_ID_BASE64",
                     "team": "${TEAM_ID.value}",
-                    "type": 0
+                    "type": 0,
+                    "protocol": "mls"
                 }
             """.trimIndent()
         private val NEW_CONVERSATION_RESPONSE =
@@ -396,7 +397,8 @@ class WireEventsIntegrationTest {
                     },
                     "group_id": "$MLS_GROUP_ID_BASE64",
                     "team": "${TEAM_ID.value}",
-                    "type": 0
+                    "type": 0,
+                    "protocol": "mls"
                 }
             """.trimIndent()
 
@@ -445,7 +447,8 @@ class WireEventsIntegrationTest {
                                 ]
                             },
                             "group_id": "$MLS_GROUP_ID_BASE64",
-                            "team": "${TEAM_ID.value}"
+                            "team": "${TEAM_ID.value}",
+                            "protocol": "mls"
                         }
                         """.trimIndent()
                     )

--- a/lib/src/test/kotlin/com/wire/integrations/jvm/service/conversation/ConversationServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/integrations/jvm/service/conversation/ConversationServiceTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.integrations.jvm.service.conversation
+
+import com.wire.crypto.toGroupId
+import com.wire.integrations.jvm.client.BackendClient
+import com.wire.integrations.jvm.crypto.CryptoClient
+import com.wire.integrations.jvm.model.CryptoProtocol
+import com.wire.integrations.jvm.model.QualifiedId
+import com.wire.integrations.jvm.model.TeamId
+import com.wire.integrations.jvm.model.http.conversation.ConversationMembers
+import com.wire.integrations.jvm.model.http.conversation.ConversationResponse
+import com.wire.integrations.jvm.persistence.AppStorage
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Base64
+import java.util.UUID
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class ConversationServiceTest {
+    @Test
+    fun whenEstablishingConversationsAndShouldRejoinConversationIsFalseThenSkip() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                coEvery { getShouldRejoinConversations() } returns false
+            }
+            val backendClient = mockk<BackendClient>()
+
+            val service = ConversationService(
+                backendClient = backendClient,
+                conversationStorage = mockk(),
+                appStorage = appStorage,
+                cryptoClient = mockk()
+            )
+
+            service.establishOrRejoinConversations()
+
+            verify(exactly = 1) {
+                appStorage.getShouldRejoinConversations()
+            }
+            coVerify(exactly = 0) {
+                backendClient.getConversationIds()
+            }
+        }
+
+    @Test
+    fun whenEstablishingConversationsAndConversationsAreEmptyThenSkipAndMarkAsRejoined() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { getShouldRejoinConversations() } returns true
+                every { setShouldRejoinConversations(any()) } returns Unit
+            }
+            val backendClient = mockk<BackendClient> {
+                coEvery { getConversationIds() } returns listOf()
+            }
+
+            val service = ConversationService(
+                backendClient = backendClient,
+                conversationStorage = mockk(),
+                appStorage = appStorage,
+                cryptoClient = mockk()
+            )
+
+            service.establishOrRejoinConversations()
+
+            verify(exactly = 1) {
+                appStorage.getShouldRejoinConversations()
+            }
+            coVerify(exactly = 1) {
+                backendClient.getConversationIds()
+            }
+            verify(exactly = 1) {
+                appStorage.setShouldRejoinConversations(false)
+            }
+        }
+
+    @Test
+    fun whenEstablishingConversationsAndConversationsExistsLocallyThenSkip() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { getShouldRejoinConversations() } returns true
+                every { setShouldRejoinConversations(any()) } returns Unit
+            }
+            val backendClient = mockk<BackendClient> {
+                coEvery { getConversationIds() } returns listOf(
+                    CONVERSATION_ID
+                )
+                coEvery {
+                    getConversationFromIds(listOf(CONVERSATION_ID))
+                } returns listOf(CONVERSATION_RESPONSE)
+            }
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(CONVERSATION_MLS_GROUP_ID) } returns true
+            }
+
+            val service = ConversationService(
+                backendClient = backendClient,
+                conversationStorage = mockk(),
+                appStorage = appStorage,
+                cryptoClient = cryptoClient
+            )
+
+            service.establishOrRejoinConversations()
+
+            verify(exactly = 1) {
+                appStorage.getShouldRejoinConversations()
+            }
+            coVerify(exactly = 1) {
+                backendClient.getConversationIds()
+            }
+            verify(exactly = 1) {
+                appStorage.setShouldRejoinConversations(false)
+            }
+            coVerify(exactly = 1) {
+                cryptoClient.conversationExists(CONVERSATION_MLS_GROUP_ID)
+            }
+        }
+
+    @Test
+    fun whenEstablishingConversationsAndConversationsDoesNotExistsLocallyThenRejoin() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { getShouldRejoinConversations() } returns true
+                every { setShouldRejoinConversations(any()) } returns Unit
+            }
+            val backendClient = mockk<BackendClient> {
+                coEvery { getConversationIds() } returns listOf(CONVERSATION_ID)
+                coEvery {
+                    getConversationFromIds(listOf(CONVERSATION_ID))
+                } returns listOf(CONVERSATION_RESPONSE)
+                coEvery {
+                    getConversationGroupInfo(conversationId = CONVERSATION_ID)
+                } returns CONVERSATION_MLS_GROUP_ID.copyBytes()
+            }
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(CONVERSATION_MLS_GROUP_ID) } returns false
+                coEvery {
+                    joinMlsConversationRequest(any())
+                } returns CONVERSATION_MLS_GROUP_ID
+            }
+
+            val service = ConversationService(
+                backendClient = backendClient,
+                conversationStorage = mockk(),
+                appStorage = appStorage,
+                cryptoClient = cryptoClient
+            )
+
+            service.establishOrRejoinConversations()
+
+            verify(exactly = 1) {
+                appStorage.getShouldRejoinConversations()
+            }
+            coVerify(exactly = 1) {
+                backendClient.getConversationIds()
+            }
+            verify(exactly = 1) {
+                appStorage.setShouldRejoinConversations(false)
+            }
+            coVerify(exactly = 1) {
+                cryptoClient.conversationExists(CONVERSATION_MLS_GROUP_ID)
+            }
+            coVerify(exactly = 1) {
+                cryptoClient.joinMlsConversationRequest(any())
+            }
+        }
+
+    private companion object {
+        val CONVERSATION_ID =
+            QualifiedId(
+                id = UUID.randomUUID(),
+                domain = "wire.com"
+            )
+        val TEAM_ID = TeamId(UUID.randomUUID())
+        val CONVERSATION_MLS_GROUP_ID = UUID.randomUUID().toString().toGroupId()
+        val CONVERSATION_MLS_GROUP_ID_BASE64 =
+            Base64.getEncoder().encodeToString(CONVERSATION_MLS_GROUP_ID.copyBytes())
+        val CONVERSATION_RESPONSE = ConversationResponse(
+            id = CONVERSATION_ID,
+            teamId = TEAM_ID.value,
+            groupId = CONVERSATION_MLS_GROUP_ID_BASE64,
+            name = "Random Conversation",
+            epoch = 1L,
+            members = ConversationMembers(others = emptyList()),
+            type = ConversationResponse.Type.GROUP,
+            protocol = CryptoProtocol.MLS
+        )
+    }
+}


### PR DESCRIPTION
* Add HTTP get for Conversations Ids and Conversations from Ids
* Add new key/value pair for ShouldRejoinConversation in AppStorage
* Use getDecodedMlsGroupId when handling mlsGroupId from ConversationResponse in EventsRouter
* Rearrange variable namings in MlsFallbackStrategy
* Move getMembersByConversationId call to conversationStorage from WireApplicationManager to ConversationService
* Make groupId and epoch as nullable in ConversationResponse to handle 1:1 and self conversations
* Add protocol to ConversationResponse
* Add ConversationListIdsRequest.kt, ConversationListIdsResponse.kt, ConversationListPaginationConfig.kt and ConversationsResponse.kt to handle getting ids and conversations to rejoin
* Set shouldRejoinConversations flag from AppStorage in CryptoClient creation based if user device was loaded or created
* Create establishOrRejoinConversations in ConversationService
* Run conversationService.establishOrRejoinConversations() from startListening in WireAppSdk so it runs everytime the SDK is started
* Add and adjust tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When re-running the SDK with a new client the SDK didn't receive messages from existing conversations

### Causes (Optional)

When a new MLS client is registered it also needs to re-join all MLS conversations

### Solutions

When SDK is started and called on `startListening` it will also fetch all existing conversations for the SDK on the backend and will re-join them.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Run the SDK first time
- Have a working conversations with another user (can send/receive messages)
- Delete `cryptography` folder and `apps.db`
- Re-run the SDK so it creates a new client and re-join existing conversations
- Everything should continue working as from the first time