### PR TITLE
chore: In Sample-java, use 'lib' directly instead of sdk dependency 

### DIFF
--- a/sample/sample-java/build.gradle.kts
+++ b/sample/sample-java/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.wire:wire-apps-jvm-sdk:0.0.16")
+    implementation(project(":lib"))
     implementation("org.slf4j:slf4j-api:2.0.17")
     implementation("ch.qos.logback:logback-classic:1.5.18")
 }


### PR DESCRIPTION
In Sample-java, use 'lib' directly instead of sdk dependency. 

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In Sample-Java, we're using SDK dependency from repo. We realised that in this case if there is a change in the lib that we want to reflect to the sample it will not be possible before releasing a new version. So we decided to use 'lib' directly as a dependency.

### Solutions

In Sample-java, use 'lib' directly instead of sdk dependency. 
