### PR TITLE
chore: Snooze 'Unknown event type' log for 'Typing' event - WPB-19587

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/model/http/EventResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/EventResponse.kt
@@ -98,6 +98,12 @@ sealed class EventContentDTO {
             @SerialName("time") val time: Instant,
             @SerialName("data") val data: String
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.typing")
+        data class Typing(
+            @SerialName("qualified_conversation") val qualifiedConversation: QualifiedId,
+        ) : Conversation()
     }
 
     @Serializable

--- a/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
@@ -179,6 +179,10 @@ internal class EventsRouter internal constructor(
                     }
                 }
 
+                is EventContentDTO.Conversation.Typing -> {
+                    // Ignore silently
+                }
+
                 is EventContentDTO.Unknown -> {
                     logger.warn("Unknown event type: {}", event)
                 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have an event called "conversation.typing" which is received for every keystroke. And this has been logging a log that says "Unknown event type" just because it was not handled in the handler. We decided to mitigate this misleading log occurrence.

### Solutions

'conversation.typing' event is handled and skipped silently.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for conversation typing events, improving compatibility with real-time interactions.
  - Typing events are recognized and safely ignored, avoiding unnecessary processing or notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->