### PR TITLE
feat: Get Self User TeamId for Creating Channel Conversation #WPB-19786

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/client/BackendClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/BackendClient.kt
@@ -32,6 +32,7 @@ import com.wire.sdk.model.http.conversation.ConversationResponse
 import com.wire.sdk.model.http.conversation.CreateConversationRequest
 import com.wire.sdk.model.http.conversation.MlsPublicKeysResponse
 import com.wire.sdk.model.http.conversation.OneToOneConversationResponse
+import com.wire.sdk.model.http.user.SelfUserResponse
 import com.wire.sdk.model.http.user.UserResponse
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import java.util.UUID
@@ -75,6 +76,8 @@ interface BackendClient {
     suspend fun getConversation(conversationId: QualifiedId): ConversationResponse
 
     suspend fun getUserData(userId: QualifiedId): UserResponse
+
+    suspend fun getSelfUser(): SelfUserResponse
 
     suspend fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray
 

--- a/lib/src/main/kotlin/com/wire/sdk/client/BackendClientDemo.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/BackendClientDemo.kt
@@ -41,6 +41,7 @@ import com.wire.sdk.model.http.conversation.ConversationsResponse
 import com.wire.sdk.model.http.conversation.CreateConversationRequest
 import com.wire.sdk.model.http.conversation.MlsPublicKeysResponse
 import com.wire.sdk.model.http.conversation.OneToOneConversationResponse
+import com.wire.sdk.model.http.user.SelfUserResponse
 import com.wire.sdk.model.http.user.UserResponse
 import com.wire.sdk.persistence.AppStorage
 import com.wire.sdk.utils.Mls
@@ -102,7 +103,7 @@ internal class BackendClientDemo(
         notificationSyncMarker = UUID.randomUUID()
         val token = loginUser()
 
-        val url = "/${BackendClient.Companion.API_VERSION}/events" +
+        val url = "/$API_VERSION/events" +
             "?client=$cachedDeviceId" +
             "&access_token=$token" +
             "&sync_marker=$notificationSyncMarker"
@@ -118,7 +119,7 @@ internal class BackendClientDemo(
 
     override suspend fun getAvailableApiVersions(): ApiVersionResponse {
         logger.info("Fetching Wire backend version")
-        return httpClient.get("/${BackendClient.Companion.API_VERSION}/api-version").body()
+        return httpClient.get("/$API_VERSION/api-version").body()
     }
 
     override suspend fun getApplicationData(): AppDataResponse {
@@ -134,7 +135,7 @@ internal class BackendClientDemo(
         logger.info("Fetching application enabled features")
         return cachedFeatures ?: run {
             val token = loginUser()
-            httpClient.get("/${BackendClient.Companion.API_VERSION}/feature-configs") {
+            httpClient.get("/$API_VERSION/feature-configs") {
                 headers {
                     append(HttpHeaders.Authorization, "Bearer $token")
                 }
@@ -168,7 +169,7 @@ internal class BackendClientDemo(
             logger.info("Access token expired, getting a new one")
         }
 
-        val loginResponse = httpClient.post("/${BackendClient.Companion.API_VERSION}/login") {
+        val loginResponse = httpClient.post("/$API_VERSION/login") {
             setBody(LoginRequest(DEMO_USER_EMAIL, DEMO_USER_PASSWORD))
             contentType(ContentType.Application.Json)
         }
@@ -308,6 +309,12 @@ internal class BackendClientDemo(
         }.body<ConversationResponse>()
     }
 
+    /**
+     * Get User details
+     *
+     * @param [QualifiedId] The ID of the user to be requested
+     * @return [UserResponse]
+     */
     override suspend fun getUserData(userId: QualifiedId): UserResponse {
         logger.info("Fetching user: $userId")
         val token = loginUser()
@@ -318,6 +325,21 @@ internal class BackendClientDemo(
                 append(HttpHeaders.Authorization, "Bearer $token")
             }
         }.body<UserResponse>()
+    }
+
+    /**
+     * Get Self User (SDK User) details
+     *
+     * @return [SelfUserResponse]
+     */
+    override suspend fun getSelfUser(): SelfUserResponse {
+        val token = loginUser()
+        return httpClient.get("/$API_VERSION/self") {
+            headers {
+                append(HttpHeaders.Authorization, "Bearer $token")
+            }
+            accept(ContentType.Application.Json)
+        }.body<SelfUserResponse>()
     }
 
     override suspend fun getConversationGroupInfo(conversationId: QualifiedId): ByteArray {

--- a/lib/src/main/kotlin/com/wire/sdk/client/BackendClientImpl.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/BackendClientImpl.kt
@@ -34,6 +34,7 @@ import com.wire.sdk.model.http.conversation.ConversationResponse
 import com.wire.sdk.model.http.conversation.CreateConversationRequest
 import com.wire.sdk.model.http.conversation.MlsPublicKeysResponse
 import com.wire.sdk.model.http.conversation.OneToOneConversationResponse
+import com.wire.sdk.model.http.user.SelfUserResponse
 import com.wire.sdk.model.http.user.UserResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -87,6 +88,10 @@ internal class BackendClientImpl(private val httpClient: HttpClient) : BackendCl
     override suspend fun confirmTeam(teamId: TeamId) {
         logger.info("Confirming team invite")
         httpClient.post("/$API_VERSION/apps/teams/${teamId.value}/confirm")
+    }
+
+    override suspend fun getSelfUser(): SelfUserResponse {
+        TODO("Not yet implemented")
     }
 
     override suspend fun updateClientWithMlsPublicKey(

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
@@ -16,7 +16,6 @@
 
 package com.wire.sdk.model.http.user
 
-import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.utils.UUIDSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -24,13 +23,7 @@ import java.util.UUID
 
 @Serializable
 data class SelfUserResponse(
-    @SerialName("qualified_id")
-    val id: QualifiedId,
     @Serializable(with = UUIDSerializer::class)
     @SerialName("team")
-    val teamId: UUID?,
-    @SerialName("email")
-    val email: String?,
-    @SerialName("name")
-    val name: String
+    val teamId: UUID?
 )

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.user
+
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.utils.UUIDSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+data class SelfUserResponse(
+    @SerialName("qualified_id")
+    val id: QualifiedId,
+    @Serializable(with = UUIDSerializer::class)
+    @SerialName("team")
+    val teamId: UUID?,
+    @SerialName("email")
+    val email: String?,
+    @SerialName("name")
+    val name: String
+)

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -353,7 +353,7 @@ class WireApplicationManager internal constructor(
      * @param userIds List of QualifiedId of all the users to be added to the conversation
      * (excluding the App user)
      *
-     * @return QualifiedId The Id of the created conversation
+     * @return QualifiedId The ID of the created conversation
      */
     fun createGroupConversation(
         name: String,
@@ -383,7 +383,7 @@ class WireApplicationManager internal constructor(
      *
      * @param userId QualifiedId of the user the App will create the conversation with
      *
-     * @return QualifiedId The Id of the created conversation
+     * @return QualifiedId The ID of the created conversation
      */
     fun createOneToOneConversation(userId: QualifiedId): QualifiedId =
         runBlocking {
@@ -404,18 +404,16 @@ class WireApplicationManager internal constructor(
      * @param userIds List of QualifiedId of all the users to be added to the conversation
      * (excluding the App user)
      *
-     * @return QualifiedId The Id of the created conversation
+     * @return QualifiedId The ID of the created conversation
      */
     fun createChannelConversation(
         name: String,
-        userIds: List<QualifiedId>,
-        teamId: TeamId
+        userIds: List<QualifiedId>
     ): QualifiedId =
         runBlocking {
             createChannelConversationSuspending(
                 name = name,
-                userIds = userIds,
-                teamId = teamId
+                userIds = userIds
             )
         }
 
@@ -424,12 +422,10 @@ class WireApplicationManager internal constructor(
      */
     suspend fun createChannelConversationSuspending(
         name: String,
-        userIds: List<QualifiedId>,
-        teamId: TeamId
+        userIds: List<QualifiedId>
     ): QualifiedId =
         conversationService.createChannel(
             name = name,
-            userIds = userIds,
-            teamId = teamId
+            userIds = userIds
         )
 }

--- a/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
@@ -146,6 +146,25 @@ object TestUtils {
                 )
             )
         )
+        wireMockServer.stubFor(
+            WireMock.get(
+                WireMock.urlPathTemplate("/$V/self")
+            ).willReturn(
+                WireMock.okJson(
+                    """
+                        {
+                          "qualified_id": {
+                            "domain": "staging.zinfra.io",
+                            "id": "b82c3381-37b0-4545-b555-ca32a3a093d0"
+                          },
+                          "team": "86fdb92f-76b8-4548-8f21-6e3fd3f5f449",
+                          "email": "sdk.user@wire.com",
+                          "name": "SDK User"
+                        }
+                    """.trimIndent()
+                )
+            )
+        )
     }
 
     fun setupSdk(eventsHandler: WireEventsHandler) {

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -19,7 +19,6 @@ package com.wire.sdk.sample
 import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.model.AssetResource
 import com.wire.sdk.model.QualifiedId
-import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.WireMessage
 import com.wire.sdk.model.WireMessage.Asset.AssetMetadata
 import com.wire.sdk.model.asset.AssetRetention
@@ -240,7 +239,7 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
     }
 
     private fun processCreateChannelConversation(wireMessage: WireMessage.Text) {
-        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN] [TEAM_ID]`
+        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN]`
         val split = wireMessage.text.split(" ")
 
         manager.createChannelConversation(
@@ -250,8 +249,7 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
                     id = UUID.fromString(split[2]),
                     domain = split[3]
                 )
-            ),
-            teamId = TeamId(value = UUID.fromString(split[4]))
+            )
         )
     }
 


### PR DESCRIPTION
* Add SelfUserResponse data class
* Add getSelfUser API request
* Remove teamId as parameter and retrieve from backend
* Adjust existing tests
* Add new test

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating a Channel conversation it was needed to pass `teamId` as a parameter.

### Causes (Optional)

After considerations and discovery we found out that a User can only create a Channel conversation on the same team it is part of and not for/to another team, so the passing of the `teamId` parameter was kind of unnecessary, although still needed when sending the request.

### Solutions

- Remove `teamId` as parameter when creating a Channel conversation
- Add backend request to get SelfUser details to get its teamId
- Get (from local populated variable in ConversationService) or fetch from the backend

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Run the SDK/Sample App
- Create a channel conversation
- Should work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added API to retrieve the authenticated user’s profile (self).
- Refactor
  - Channel creation now derives team from the authenticated user; callers no longer supply a team ID (app and sample updated).
- Documentation
  - Updated docs/comments and sample usage to reflect team-less channel creation.
- Tests
  - Added tests covering successful channel creation with inferred team and the error case when the user has no team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->