### PR TITLE
chore: Auto update versions in readme on release - #WPB-19588

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-24.04
@@ -23,6 +26,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
 
       - name: Update README.md with new version
+        continue-on-error: true
         run: |
           set -euo pipefail
           VERSION="${{ github.event.release.tag_name }}"
@@ -39,15 +43,18 @@ jobs:
           }' README.md
 
       - name: Commit and push README.md update
+        continue-on-error: true
         run: |
           set -euo pipefail
           VERSION="${{ github.event.release.tag_name }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
           if git diff --quiet -- README.md; then
             echo "No README.md changes to commit"
             exit 0
           fi
+          
           git add README.md
           git commit -m "docs(readme): update dependency version to ${VERSION}"
           git push origin HEAD:"${{ github.event.repository.default_branch }}"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Gradle and Maven dependency versions are not updated automatically on each release. We wanted to automate this.


### Solutions

This PR introduces automation to keep the dependency snippets in README.md up to date with the latest release version.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - README now auto-updates dependency snippets (Gradle/Maven) to the latest released version, ensuring installation instructions are always current after each release.

- Chores
  - Release pipeline enhanced to automatically update and push README version changes, committing only when updates are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->