### PR TITLE
Fix/crash on unavailable backend api

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -100,6 +100,8 @@ val sdkModule =
         single { WireApplicationManager(get(), get(), get(), get(), get(), get()) }
     }
 
+internal const val MAX_RETRY_NUMBER_ON_SERVER_ERROR = 10
+
 @OptIn(ExperimentalLogbookKtorApi::class)
 internal fun createHttpClient(apiHost: String?): HttpClient {
     return HttpClient(CIO) {

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -133,7 +133,7 @@ internal fun createHttpClient(apiHost: String?): HttpClient {
 
         install(HttpCache)
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = 3)
+            retryOnServerErrors(maxRetries = MAX_RETRY_NUMBER_ON_SERVER_ERROR)
             exponentialDelay()
         }
 

--- a/lib/src/main/kotlin/com/wire/sdk/exception/WireException.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/exception/WireException.kt
@@ -74,9 +74,9 @@ sealed class WireException @JvmOverloads constructor(
     ) : WireException(response.message, throwable)
 
     /**
-     * Internal Error
+     * Server Error
      */
-    data class InternalSystemError(
+    data class ServerError(
         val response: StandardError,
         val throwable: Throwable?
     ) : WireException(response.message, throwable)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Apps build on top of SDK became unresponsive.

### Causes

- The Staging Backend API was down longer than the SDK client's maximum retry duration. The final retry occurred before the backend was back online.
- When Staging Backend is down it responds with html body causing `NoTransformationFoundException` which was left unmapped to SDK exception.

### Solutions

- Increase the maximum number of retries when issue lays on server side, so the last try happens after half an hour instead of seven minutes.
- Catch and log error response with html content type.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
