### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# What's new in this PR?

Setting up a cooldown period for dependency updates 

----
##### References
1. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
