### PR TITLE
fix: WPB-25215 fix on removing multiple user from channel

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/client/UsersApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/UsersApiClient.kt
@@ -17,6 +17,8 @@
 package com.wire.sdk.client
 
 import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.http.user.ListClientsRequest
+import com.wire.sdk.model.http.user.ListClientsResponse
 import com.wire.sdk.model.http.user.UserClientResponse
 import com.wire.sdk.model.http.user.UserResponse
 import io.ktor.client.HttpClient
@@ -61,17 +63,15 @@ internal class UsersApiClient(private val httpClient: HttpClient) {
         userIds: List<QualifiedId>
     ): Map<QualifiedId, List<UserClientResponse>> {
         val response = httpClient.post("/$basePath/list-clients") {
-            setBody(userIds)
+            setBody(ListClientsRequest(qualifiedUsers = userIds))
             contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)
-        }.body<Map<String, Map<String, List<UserClientResponse>>>>()
+        }.body<ListClientsResponse>()
 
-        val usersClients = response.flatMap { (domain, users) ->
+        return response.qualifiedUserMap.flatMap { (domain, users) ->
             users.map { (userId, clients) ->
                 QualifiedId(UUID.fromString(userId), domain) to clients
             }
         }.toMap()
-
-        return usersClients
     }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsRequest.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsRequest.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.user
+
+import com.wire.sdk.model.QualifiedId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ListClientsRequest(
+    @SerialName("qualified_users") val qualifiedUsers: List<QualifiedId>
+)

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsResponse.kt
@@ -21,5 +21,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ListClientsResponse(
-    @SerialName("qualified_user_map") val qualifiedUserMap: Map<String, Map<String, List<UserClientResponse>>>
+    @SerialName("qualified_user_map") val qualifiedUserMap:
+        Map<String, Map<String, List<UserClientResponse>>>
 )

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/ListClientsResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ListClientsResponse(
+    @SerialName("qualified_user_map") val qualifiedUserMap: Map<String, Map<String, List<UserClientResponse>>>
+)

--- a/lib/src/test/kotlin/com/wire/sdk/client/UsersApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/UsersApiClientTest.kt
@@ -25,6 +25,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.test.runTest
@@ -157,6 +158,32 @@ class UsersApiClientTest {
         }
 
     @Test
+    fun `given userIds,when getClientsByUserIds, then request body contains qualified_users key`() =
+        runTest {
+            var capturedBody: String? = null
+            apiClient(LIST_CLIENTS_RESPONSE_JSON) {
+                capturedBody = (it.body as TextContent).text
+            }.getClientsByUserIds(listOf(USER_ID))
+            assertTrue(
+                capturedBody?.contains("\"qualified_users\"") == true,
+                "Request body must contain qualified_users key, was: $capturedBody"
+            )
+        }
+
+    @Test
+    fun `given userIds, when getClientsByUserIds, then request body is not a bare array`() =
+        runTest {
+            var capturedBody: String? = null
+            apiClient(LIST_CLIENTS_RESPONSE_JSON) {
+                capturedBody = (it.body as TextContent).text
+            }.getClientsByUserIds(listOf(USER_ID))
+            assertTrue(
+                capturedBody?.trimStart()?.startsWith("[") == false,
+                "Request body must not be a bare array, was: $capturedBody"
+            )
+        }
+
+    @Test
     fun `given multi-domain, when getClientsByUserIds, then keyed by QualifiedId`() =
         runTest {
             val result = apiClient(LIST_CLIENTS_RESPONSE_JSON)
@@ -180,7 +207,8 @@ class UsersApiClientTest {
     @Test
     fun `given empty response, when getClientsByUserIds, then empty map`() =
         runTest {
-            val result = apiClient("{}").getClientsByUserIds(emptyList())
+            val result =
+                apiClient(EMPTY_LIST_CLIENTS_RESPONSE_JSON).getClientsByUserIds(emptyList())
             assertTrue(result.isEmpty())
         }
 
@@ -255,20 +283,28 @@ class UsersApiClientTest {
 
         private val LIST_CLIENTS_RESPONSE_JSON = """
             {
-                "example.com": {
-                    "${USER_ID.id}": [
-                        { "id": "client-abc" },
-                        { "id": "client-def" }
-                    ],
-                    "${SECOND_USER_ID.id}": [
-                        { "id": "client-xyz" }
-                    ]
-                },
-                "other.com": {
-                    "${REMOTE_USER_ID.id}": [
-                        { "id": "client-remote" }
-                    ]
+                "qualified_user_map": {
+                    "example.com": {
+                        "${USER_ID.id}": [
+                            { "id": "client-abc" },
+                            { "id": "client-def" }
+                        ],
+                        "${SECOND_USER_ID.id}": [
+                            { "id": "client-xyz" }
+                        ]
+                    },
+                    "other.com": {
+                        "${REMOTE_USER_ID.id}": [
+                            { "id": "client-remote" }
+                        ]
+                    }
                 }
+            }
+        """.trimIndent()
+
+        private val EMPTY_LIST_CLIENTS_RESPONSE_JSON = """
+            {
+                "qualified_user_map": {}
             }
         """.trimIndent()
     }

--- a/lib/src/test/kotlin/com/wire/sdk/model/http/user/ListClientsRequestTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/http/user/ListClientsRequestTest.kt
@@ -1,0 +1,219 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.user
+
+import com.wire.sdk.model.QualifiedId
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class ListClientsRequestTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `serializes qualified_users key correctly`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val request = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+
+        val result = json.encodeToString(request)
+
+        assertTrue(result.contains("\"qualified_users\""))
+    }
+
+    @Test
+    fun `serializes single user correctly`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val request = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+
+        val result = json.encodeToString(request)
+        val expected =
+            """{"qualified_users":[{"id":"99db9768-04e3-4b5d-9268-831b6a25c4ab","domain":"example.com"}]}"""
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `serializes multiple users correctly`() {
+        val userId1 = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val userId2 = UUID.fromString("1d51e2d6-9c70-605f-efc8-ff85c3dabdc7")
+        val request = ListClientsRequest(
+            qualifiedUsers = listOf(
+                QualifiedId(id = userId1, domain = "example.com"),
+                QualifiedId(id = userId2, domain = "staging.zinfra.io")
+            )
+        )
+
+        val result = json.encodeToString(request)
+        val expected =
+            """{"qualified_users":[{"id":"99db9768-04e3-4b5d-9268-831b6a25c4ab","domain":"example.com"},{"id":"1d51e2d6-9c70-605f-efc8-ff85c3dabdc7","domain":"staging.zinfra.io"}]}"""
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `serializes empty user list correctly`() {
+        val request = ListClientsRequest(qualifiedUsers = emptyList())
+
+        val result = json.encodeToString(request)
+        val expected = """{"qualified_users":[]}"""
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `does not serialize as bare array`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val request = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+
+        val result = json.encodeToString(request)
+
+        assertFalse(
+            result.startsWith("["),
+            "Body must not be a bare array — API expects an object with qualified_users key"
+        )
+    }
+
+    @Test
+    fun `deserializes single user correctly`() {
+        val jsonString =
+            """{"qualified_users":[{"id":"99db9768-04e3-4b5d-9268-831b6a25c4ab","domain":"example.com"}]}"""
+
+        val result = json.decodeFromString<ListClientsRequest>(jsonString)
+
+        assertEquals(1, result.qualifiedUsers.size)
+        assertEquals(
+            UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab"),
+            result.qualifiedUsers[0].id
+        )
+        assertEquals("example.com", result.qualifiedUsers[0].domain)
+    }
+
+    @Test
+    fun `deserializes multiple users correctly`() {
+        val jsonString =
+            """{"qualified_users":[{"id":"99db9768-04e3-4b5d-9268-831b6a25c4ab","domain":"example.com"},{"id":"1d51e2d6-9c70-605f-efc8-ff85c3dabdc7","domain":"staging.zinfra.io"}]}"""
+
+        val result = json.decodeFromString<ListClientsRequest>(jsonString)
+
+        assertEquals(2, result.qualifiedUsers.size)
+        assertEquals("example.com", result.qualifiedUsers[0].domain)
+        assertEquals("staging.zinfra.io", result.qualifiedUsers[1].domain)
+    }
+
+    @Test
+    fun `deserializes empty user list correctly`() {
+        val jsonString = """{"qualified_users":[]}"""
+
+        val result = json.decodeFromString<ListClientsRequest>(jsonString)
+
+        assertTrue(result.qualifiedUsers.isEmpty())
+    }
+
+    @Test
+    fun `two requests with same users are equal`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val request1 = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+        val request2 = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+
+        assertEquals(request1, request2)
+    }
+
+    @Test
+    fun `two requests with different users are not equal`() {
+        val request1 = ListClientsRequest(
+            qualifiedUsers = listOf(
+                QualifiedId(
+                    id = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab"),
+                    domain = "example.com"
+                )
+            )
+        )
+        val request2 = ListClientsRequest(
+            qualifiedUsers = listOf(
+                QualifiedId(
+                    id = UUID.fromString("1d51e2d6-9c70-605f-efc8-ff85c3dabdc7"),
+                    domain = "example.com"
+                )
+            )
+        )
+
+        assertNotEquals(request1, request2)
+    }
+
+    @Test
+    fun `two requests with different domains are not equal`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val request1 = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "example.com"))
+        )
+        val request2 = ListClientsRequest(
+            qualifiedUsers = listOf(QualifiedId(id = userId, domain = "staging.zinfra.io"))
+        )
+
+        assertNotEquals(request1, request2)
+    }
+
+    @Test
+    fun `serialization round-trip preserves data`() {
+        val userId = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        val original = ListClientsRequest(
+            qualifiedUsers = listOf(
+                QualifiedId(id = userId, domain = "example.com")
+            )
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ListClientsRequest>(encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialization round-trip preserves multiple users`() {
+        val original = ListClientsRequest(
+            qualifiedUsers = listOf(
+                QualifiedId(
+                    id = UUID.fromString("99db9768-04e3-4b5d-9268-831b6a25c4ab"),
+                    domain = "example.com"
+                ),
+                QualifiedId(
+                    id = UUID.fromString("1d51e2d6-9c70-605f-efc8-ff85c3dabdc7"),
+                    domain = "staging.zinfra.io"
+                )
+            )
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ListClientsRequest>(encoded)
+
+        assertEquals(original, decoded)
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/model/http/user/ListClientsResponseTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/http/user/ListClientsResponseTest.kt
@@ -1,0 +1,326 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.user
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ListClientsResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `deserializes qualified_user_map key correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        assertTrue(result.qualifiedUserMap.containsKey("example.com"))
+    }
+
+    @Test
+    fun `deserializes single domain single user single client correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        val clients =
+            result.qualifiedUserMap["example.com"]?.get("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        assertNotNull(clients)
+        assertEquals(1, clients!!.size)
+        assertEquals("d0", clients[0].id)
+    }
+
+    @Test
+    fun `deserializes single domain single user multiple clients correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0" },
+                            { "id": "d1" },
+                            { "id": "d2" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        val clients =
+            result.qualifiedUserMap["example.com"]?.get("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        assertNotNull(clients)
+        assertEquals(3, clients!!.size)
+        assertEquals(listOf("d0", "d1", "d2"), clients.map { it.id })
+    }
+
+    @Test
+    fun `deserializes single domain multiple users correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0" }
+                        ],
+                        "1d51e2d6-9c70-605f-efc8-ff85c3dabdc7": [
+                            { "id": "d1" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        val domainMap = result.qualifiedUserMap["example.com"]
+        assertNotNull(domainMap)
+        assertEquals(2, domainMap!!.size)
+        assertEquals("d0", domainMap["99db9768-04e3-4b5d-9268-831b6a25c4ab"]?.first()?.id)
+        assertEquals("d1", domainMap["1d51e2d6-9c70-605f-efc8-ff85c3dabdc7"]?.first()?.id)
+    }
+
+    @Test
+    fun `deserializes multiple domains correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0" }
+                        ]
+                    },
+                    "staging.zinfra.io": {
+                        "1d51e2d6-9c70-605f-efc8-ff85c3dabdc7": [
+                            { "id": "d1" }
+                        ]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        assertEquals(2, result.qualifiedUserMap.size)
+        assertTrue(result.qualifiedUserMap.containsKey("example.com"))
+        assertTrue(result.qualifiedUserMap.containsKey("staging.zinfra.io"))
+    }
+
+    @Test
+    fun `deserializes empty qualified_user_map correctly`() {
+        val jsonString = """{"qualified_user_map": {}}"""
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        assertTrue(result.qualifiedUserMap.isEmpty())
+    }
+
+    @Test
+    fun `deserializes user with empty client list correctly`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": []
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        val clients =
+            result.qualifiedUserMap["example.com"]?.get("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+        assertNotNull(clients)
+        assertTrue(clients!!.isEmpty())
+    }
+
+    @Test
+    fun `ignores unknown keys in response`() {
+        val jsonString = """
+            {
+                "qualified_user_map": {
+                    "example.com": {
+                        "99db9768-04e3-4b5d-9268-831b6a25c4ab": [
+                            { "id": "d0", "unknown_field": "should_be_ignored" }
+                        ]
+                    }
+                },
+                "unexpected_top_level_key": "should_be_ignored"
+            }
+        """.trimIndent()
+
+        val result = json.decodeFromString<ListClientsResponse>(jsonString)
+
+        assertEquals(
+            "d0",
+            result.qualifiedUserMap["example.com"]
+                ?.get("99db9768-04e3-4b5d-9268-831b6a25c4ab")
+                ?.first()?.id
+        )
+    }
+
+    @Test
+    fun `serializes qualified_user_map key correctly`() {
+        val response = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+
+        val result = json.encodeToString(response)
+
+        assertTrue(result.contains("\"qualified_user_map\""))
+    }
+
+    @Test
+    fun `serializes empty map correctly`() {
+        val response = ListClientsResponse(qualifiedUserMap = emptyMap())
+
+        val result = json.encodeToString(response)
+        val expected = """{"qualified_user_map":{}}"""
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `two responses with same data are equal`() {
+        val response1 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+        val response2 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+
+        assertEquals(response1, response2)
+    }
+
+    @Test
+    fun `two responses with different domains are not equal`() {
+        val response1 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+        val response2 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "staging.zinfra.io" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+
+        assertNotEquals(response1, response2)
+    }
+
+    @Test
+    fun `two responses with different client ids are not equal`() {
+        val response1 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+        val response2 = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d1"))
+                )
+            )
+        )
+
+        assertNotEquals(response1, response2)
+    }
+
+    @Test
+    fun `serialization round-trip preserves single domain single user`() {
+        val original = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(UserClientResponse(id = "d0"))
+                )
+            )
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ListClientsResponse>(encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialization round-trip preserves multiple domains and users`() {
+        val original = ListClientsResponse(
+            qualifiedUserMap = mapOf(
+                "example.com" to mapOf(
+                    "99db9768-04e3-4b5d-9268-831b6a25c4ab" to listOf(
+                        UserClientResponse(id = "d0"),
+                        UserClientResponse(id = "d1")
+                    )
+                ),
+                "staging.zinfra.io" to mapOf(
+                    "1d51e2d6-9c70-605f-efc8-ff85c3dabdc7" to listOf(
+                        UserClientResponse(id = "d2")
+                    )
+                )
+            )
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ListClientsResponse>(encoded)
+
+        assertEquals(original, decoded)
+    }
+}

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -95,13 +96,26 @@ class TestCommandProcessor {
     }
 
     private void processRemoveMemberFromConversation(WireMessage.Text wireMessage) {
-        // Expected message: `remove-members-from-conversation [USER_ID] [DOMAIN]
-        final var split = wireMessage.text().split(" ");
-        final var members = List.of(new QualifiedId(UUID.fromString(split[1]), split[2]));
-        this.manager.removeMembersFromConversation(
+        // Expected message: `remove-members-from-conversation [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
+        final String[] split = wireMessage.text().split(" ");
+        final List<QualifiedId> members = new ArrayList<>();
+
+        // Start at index 1, increment by 2 to capture pairs of UUID and Domain
+        for (int i = 1; i < split.length; i += 2) {
+            // Basic check to ensure we have a Domain for the current UUID
+            if (i + 1 < split.length) {
+                var userId = UUID.fromString(split[i]);
+                var domain = split[i + 1];
+                members.add(new QualifiedId(userId, domain));
+            }
+        }
+
+        if (!members.isEmpty()) {
+            this.manager.removeMembersFromConversation(
                 wireMessage.conversationId(),
                 members
-        );
+            );
+        }
     }
 
     private void processAssetImage(WireMessage.Text wireMessage) {

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -239,18 +239,24 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
     }
 
     private suspend fun processRemoveMembersFromConversation(wireMessage: WireMessage.Text) {
-        // Expected message: `remove-members-from-conversation [USER_ID] [DOMAIN]
-         val split = wireMessage.text.split(" ")
+        // Expected message: `remove-members-from-conversation [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
+        val split = wireMessage.text.split(" ")
+        val members = mutableListOf<QualifiedId>()
 
-        manager.removeMembersFromConversationSuspending(
-            conversationId = wireMessage.conversationId,
-            members = listOf(
-                QualifiedId(
-                    id = UUID.fromString(split[1]),
-                    domain = split[2]
-                )
+        // Start at index 1, increment by 2 to capture pairs of UUID and Domain
+        for (i in 1 until split.size step 2) {
+            // Basic check to ensure we have a Domain for the current UUID
+            if (i + 1 < split.size) {
+                members.add(QualifiedId(id = UUID.fromString(split[i]), domain = split[i + 1]))
+            }
+        }
+
+        if (members.isNotEmpty()) {
+            manager.removeMembersFromConversationSuspending(
+                conversationId = wireMessage.conversationId,
+                members = members
             )
-        )
+        }
     }
 
     private suspend fun processCreateOneToOneConversation(wireMessage: WireMessage.Text) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³
----

# What's new in this PR?

### Issues
Deleting multiple members from the conversation flow has a bug because of the mismatch in request/response structure of the related backend point `/list-clients`

### Solutions
Implement the fix in the UserApiClient class by introducing the proper Request and Response classes based on the information Swagger provides. https://staging-nginz-https.zinfra.io/v15/api/swagger-ui/#/default/list-clients-bulk%40v2 

### Testing
#### How to Test
1. Run Java sample app
2. Create a group conversation and make the app an admin. (Or create the conversation through the app. So the app will be admin automatically.)
3. Add multiple users to the conversation to use them for test.
4. Type `remove-members-from-conversation [USER_ID] [DOMAIN] [USER_ID] [DOMAIN]`
5. Send the message
6. Verify that the mentioned members are removed from the conversation. 