### PR TITLE
feat: WPB-25158 Add 'search users' capability

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.client
+
+import com.wire.sdk.model.http.search.SearchContactsResponse
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import org.slf4j.LoggerFactory
+
+internal class SearchApiClient(private val httpClient: HttpClient) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val basePath = "search"
+
+    private companion object {
+        const val QUERY_KEY = "q"
+        const val DOMAIN_KEY = "domain"
+        const val SIZE_KEY = "size"
+        const val TYPE_KEY = "type"
+
+        const val DEFAULT_SIZE = 15
+        const val MIN_SIZE = 1
+        const val MAX_SIZE = 500
+    }
+
+    suspend fun searchContacts(
+        query: String,
+        domain: String? = null,
+        size: Int = DEFAULT_SIZE,
+        type: String? = null
+    ): SearchContactsResponse {
+        require(query.isNotBlank()) { "Search query must not be blank." }
+        require(size in MIN_SIZE..MAX_SIZE) { "Size must be between $MIN_SIZE and $MAX_SIZE." }
+
+        logger.debug(
+            "Searching contacts with query='{}', domain='{}', size={}, type={}",
+            query, domain, size, type
+        )
+
+        return httpClient.get("/$basePath/contacts") {
+            parameter(QUERY_KEY, query)
+            domain?.let { parameter(DOMAIN_KEY, it) }
+            type?.let { parameter(TYPE_KEY, it) }
+            parameter(SIZE_KEY, size)
+        }.body<SearchContactsResponse>()
+    }
+}

--- a/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
@@ -36,25 +36,27 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
     suspend fun searchUsers(
         query: String,
         domain: String? = null,
-        numberOfResults: Int? = DEFAULT_RESULT_SIZE
+        numberOfResults: Int? = null
     ): SearchContactsResponse {
-        require(query.isNotBlank()) { "Search query must not be blank." }
-        require(numberOfResults in MIN_RESULT_SIZE..MAX_RESULT_SIZE) {
+        val size = numberOfResults ?: DEFAULT_RESULT_SIZE
+
+        require(size in MIN_RESULT_SIZE..MAX_RESULT_SIZE) {
             "Size must be between $MIN_RESULT_SIZE and $MAX_RESULT_SIZE."
         }
+        require(query.isNotBlank()) { "Search query must not be blank." }
 
         logger.debug(
-            "Searching users with query='{}', domain='{}', numberOfResults={}",
+            "Searching users with query='{}', domain='{}', size={}",
             query,
             domain,
-            numberOfResults
+            size
         )
 
         return httpClient.get("/$basePath/contacts") {
             parameter("q", query)
             domain?.let { parameter("domain", it) }
             parameter("type", "regular") // Search users only, not apps.
-            parameter("size", numberOfResults)
+            parameter("size", size)
         }.body<SearchContactsResponse>()
     }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
@@ -17,9 +17,10 @@
 package com.wire.sdk.client
 
 import com.wire.sdk.model.http.search.SearchContactsResponse
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.request.*
+import io.ktor.client.call.body
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import org.slf4j.LoggerFactory
 
 internal class SearchApiClient(private val httpClient: HttpClient) {
@@ -27,35 +28,33 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
     private val basePath = "search"
 
     private companion object {
-        const val QUERY_KEY = "q"
-        const val DOMAIN_KEY = "domain"
-        const val SIZE_KEY = "size"
-        const val TYPE_KEY = "type"
-
-        const val DEFAULT_SIZE = 15
-        const val MIN_SIZE = 1
-        const val MAX_SIZE = 500
+        const val DEFAULT_RESULT_SIZE = 15
+        const val MIN_RESULT_SIZE = 1
+        const val MAX_RESULT_SIZE = 500
     }
 
-    suspend fun searchContacts(
+    suspend fun searchUsers(
         query: String,
         domain: String? = null,
-        size: Int = DEFAULT_SIZE,
-        type: String? = null
+        numberOfResults: Int? = DEFAULT_RESULT_SIZE
     ): SearchContactsResponse {
         require(query.isNotBlank()) { "Search query must not be blank." }
-        require(size in MIN_SIZE..MAX_SIZE) { "Size must be between $MIN_SIZE and $MAX_SIZE." }
+        require(numberOfResults in MIN_RESULT_SIZE..MAX_RESULT_SIZE) {
+            "Size must be between $MIN_RESULT_SIZE and $MAX_RESULT_SIZE."
+        }
 
         logger.debug(
-            "Searching contacts with query='{}', domain='{}', size={}, type={}",
-            query, domain, size, type
+            "Searching users with query='{}', domain='{}', numberOfResults={}",
+            query,
+            domain,
+            numberOfResults
         )
 
         return httpClient.get("/$basePath/contacts") {
-            parameter(QUERY_KEY, query)
-            domain?.let { parameter(DOMAIN_KEY, it) }
-            type?.let { parameter(TYPE_KEY, it) }
-            parameter(SIZE_KEY, size)
+            parameter("q", query)
+            domain?.let { parameter("domain", it) }
+            parameter("type", "regular") // Search users only, not apps.
+            parameter("size", numberOfResults)
         }.body<SearchContactsResponse>()
     }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
@@ -35,7 +35,7 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
 
     suspend fun searchUsers(
         query: String,
-        domain: String? = null,
+        domain: String,
         numberOfResults: Int? = null
     ): SearchContactsResponse {
         val size = numberOfResults ?: DEFAULT_RESULT_SIZE
@@ -44,6 +44,7 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
             "Number of results value must be between $MIN_RESULT_SIZE and $MAX_RESULT_SIZE."
         }
         require(query.isNotBlank()) { "Search query must not be blank." }
+        require(domain.isNotBlank()) { "Domain must not be blank." }
 
         logger.debug(
             "Searching users with query='{}', domain='{}', size={}",
@@ -54,7 +55,7 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
 
         return httpClient.get("/$basePath/contacts") {
             parameter("q", query)
-            domain?.let { parameter("domain", it) }
+            parameter("domain", domain)
             parameter("type", "regular") // Search users only, not apps.
             parameter("size", size)
         }.body<SearchContactsResponse>()

--- a/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/SearchApiClient.kt
@@ -41,7 +41,7 @@ internal class SearchApiClient(private val httpClient: HttpClient) {
         val size = numberOfResults ?: DEFAULT_RESULT_SIZE
 
         require(size in MIN_RESULT_SIZE..MAX_RESULT_SIZE) {
-            "Size must be between $MIN_RESULT_SIZE and $MAX_RESULT_SIZE."
+            "Number of results value must be between $MIN_RESULT_SIZE and $MAX_RESULT_SIZE."
         }
         require(query.isNotBlank()) { "Search query must not be blank." }
 

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -29,6 +29,7 @@ import com.wire.sdk.client.ConversationsApiClient
 import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.client.NotificationsApiClient
 import com.wire.sdk.client.OneToOneConversationsApiClient
+import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.client.SelfApiClient
 import com.wire.sdk.client.TeamsApiClient
 import com.wire.sdk.client.UsersApiClient
@@ -100,6 +101,7 @@ val sdkModule =
         single<SelfApiClient> { SelfApiClient(get()) }
         single<AssetsApiClient> { AssetsApiClient(get()) }
         single<TeamsApiClient> { TeamsApiClient(get()) }
+        single<SearchApiClient> { SearchApiClient(get()) }
         single<NotificationsApiClient> { NotificationsApiClient(get(), get()) }
         single<ClientsApiClient> { ClientsApiClient(get(), get()) }
         single<MlsApiClient> { MlsApiClient(get(), get()) }
@@ -135,7 +137,7 @@ val sdkModule =
         }
 
         // Manager
-        single { WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single { WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     }
 
 internal const val MAX_RETRY_NUMBER_ON_SERVER_ERROR = 10

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -137,7 +137,9 @@ val sdkModule =
         }
 
         // Manager
-        single { WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+        single {
+            WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get(), get())
+        }
     }
 
 internal const val MAX_RETRY_NUMBER_ON_SERVER_ERROR = 10

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
@@ -41,17 +41,15 @@ data class SearchContactsResponse(
     @SerialName("documents")
     val documents: List<ContactDocument>,
     @SerialName("found")
-    val found: Long,
+    val found: Long? = null,
     @SerialName("has_more")
-    val hasMore: Boolean? = null, // TODO: Is it ok to have null as default? Actually seems better than true or false.
+    val hasMore: Boolean? = null,
     @SerialName("paging_state")
-    val pagingState: String?,
+    val pagingState: String? = null,
     @SerialName("returned")
-    val returned: Long,
-    @SerialName("search_policy")
-    val searchPolicy: SearchPolicy,
+    val returned: Long? = null,
     @SerialName("took")
-    val took: Long
+    val took: Long? = null,
 )
 
 @Serializable
@@ -69,35 +67,6 @@ data class ContactDocument(
     @SerialName("team")
     val team: String?,
     @SerialName("type")
-    val type: UserType?
+    val type: String?
 )
 
-@Serializable
-enum class SearchPolicy {
-    @SerialName("no_search")
-    NO_SEARCH,
-
-    @SerialName("exact_handle_search")
-    EXACT_HANDLE_SEARCH,
-
-    @SerialName("full_search")
-    FULL_SEARCH
-}
-
-@Serializable
-enum class UserType {
-    @SerialName("regular")
-    REGULAR,
-
-    @SerialName("bot")
-    BOT,
-
-    @SerialName("external")
-    EXTERNAL,
-
-    @SerialName("federated")
-    FEDERATED,
-
-    @SerialName("guest")
-    GUEST
-}

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
@@ -16,22 +16,6 @@
 
 package com.wire.sdk.model.http.search
 
-/*
- * Wire
- * Copyright (C) 2026 Wire Swiss GmbH
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
- */
-
 import com.wire.sdk.model.QualifiedId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -49,7 +33,7 @@ data class SearchContactsResponse(
     @SerialName("returned")
     val returned: Long? = null,
     @SerialName("took")
-    val took: Long? = null,
+    val took: Long? = null
 )
 
 @Serializable
@@ -69,4 +53,3 @@ data class ContactDocument(
     @SerialName("type")
     val type: String?
 )
-

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model.http.search
+
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import com.wire.sdk.model.QualifiedId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SearchContactsResponse(
+    @SerialName("documents")
+    val documents: List<ContactDocument>,
+    @SerialName("found")
+    val found: Long,
+    @SerialName("has_more")
+    val hasMore: Boolean? = null, // TODO: Is it ok to have null as default? Actually seems better than true or false.
+    @SerialName("paging_state")
+    val pagingState: String?,
+    @SerialName("returned")
+    val returned: Long,
+    @SerialName("search_policy")
+    val searchPolicy: SearchPolicy,
+    @SerialName("took")
+    val took: Long
+)
+
+@Serializable
+data class ContactDocument(
+    @SerialName("accent_id")
+    val accentId: Long?,
+    @SerialName("handle")
+    val handle: String?,
+    @SerialName("id")
+    val id: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("qualified_id")
+    val qualifiedId: QualifiedId?,
+    @SerialName("team")
+    val team: String?,
+    @SerialName("type")
+    val type: UserType?
+)
+
+@Serializable
+enum class SearchPolicy {
+    @SerialName("no_search")
+    NO_SEARCH,
+
+    @SerialName("exact_handle_search")
+    EXACT_HANDLE_SEARCH,
+
+    @SerialName("full_search")
+    FULL_SEARCH
+}
+
+@Serializable
+enum class UserType {
+    @SerialName("regular")
+    REGULAR,
+
+    @SerialName("bot")
+    BOT,
+
+    @SerialName("external")
+    EXTERNAL,
+
+    @SerialName("federated")
+    FEDERATED,
+
+    @SerialName("guest")
+    GUEST
+}

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -655,7 +655,7 @@ class WireApplicationManager internal constructor(
     /**
      * Searches for Wire users matching the given query.
      *
-     * @param queryFor The search string to match against user names and handles.
+     * @param query The search string to match against user names and handles.
      * @param domain The domain to restrict the search to, or null to search across all domains.
      * @param numberOfResults The maximum number of results to return,
      * or null to use the backend default.
@@ -663,13 +663,13 @@ class WireApplicationManager internal constructor(
      * @throws WireException If the request fails or an error occurs while searching.
      */
     fun searchUsers(
-        queryFor: String,
+        query: String,
         domain: String? = null,
         numberOfResults: Int? = null
     ): SearchContactsResponse {
         return runBlocking {
             searchUsersSuspending(
-                queryFor = queryFor,
+                query = query,
                 domain = domain,
                 numberOfResults = numberOfResults
             )
@@ -680,12 +680,12 @@ class WireApplicationManager internal constructor(
      * See [searchUsers]
      */
     suspend fun searchUsersSuspending(
-        queryFor: String,
+        query: String,
         domain: String? = null,
         numberOfResults: Int? = null
     ): SearchContactsResponse {
         return searchApiClient.searchUsers(
-            query = queryFor,
+            query = query,
             domain = domain,
             numberOfResults = numberOfResults
         )

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -18,6 +18,7 @@ package com.wire.sdk.service
 import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
+import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.exception.WireException
@@ -34,6 +35,7 @@ import com.wire.sdk.model.asset.AssetUploadData
 import com.wire.sdk.model.conversation.AddMembersToConversationResult
 import com.wire.sdk.model.http.ApiVersionResponse
 import com.wire.sdk.model.http.conversation.ConversationRole
+import com.wire.sdk.model.http.search.SearchContactsResponse
 import com.wire.sdk.model.http.user.UserResponse
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
@@ -61,6 +63,7 @@ class WireApplicationManager internal constructor(
     private val usersApiClient: UsersApiClient,
     private val mlsApiClient: MlsApiClient,
     private val assetsApiClient: AssetsApiClient,
+    private val searchApiClient: SearchApiClient,
     private val cryptoClient: CryptoClient,
     private val mlsFallbackStrategy: MlsFallbackStrategy,
     private val conversationService: ConversationService
@@ -648,4 +651,13 @@ class WireApplicationManager internal constructor(
             members = members
         )
     }
+
+    fun searchContacts(): SearchContactsResponse {
+        return runBlocking {
+            searchApiClient.searchContacts(
+                query = "baris"
+            )
+        }
+    }
+
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -652,12 +652,41 @@ class WireApplicationManager internal constructor(
         )
     }
 
-    fun searchContacts(): SearchContactsResponse {
+    /**
+     * Searches for Wire users matching the given query.
+     *
+     * @param queryFor The search string to match against user names and handles.
+     * @param domain The domain to restrict the search to, or null to search across all domains.
+     * @param numberOfResults The maximum number of results to return, or null to use the backend default.
+     * @return A [SearchContactsResponse] containing the list of matched users.
+     * @throws WireException If the request fails or an error occurs while searching.
+     */
+    fun searchUsers(
+        queryFor: String,
+        domain: String? = null,
+        numberOfResults: Int? = null
+    ): SearchContactsResponse {
         return runBlocking {
-            searchApiClient.searchContacts(
-                query = "baris"
+            searchUsersSuspending(
+                queryFor = queryFor,
+                domain = domain,
+                numberOfResults = numberOfResults
             )
         }
     }
 
+    /**
+     * See [searchUsers]
+     */
+    suspend fun searchUsersSuspending(
+        queryFor: String,
+        domain: String? = null,
+        numberOfResults: Int? = null
+    ): SearchContactsResponse {
+        return searchApiClient.searchUsers(
+            query = queryFor,
+            domain = domain,
+            numberOfResults = numberOfResults
+        )
+    }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -657,7 +657,8 @@ class WireApplicationManager internal constructor(
      *
      * @param queryFor The search string to match against user names and handles.
      * @param domain The domain to restrict the search to, or null to search across all domains.
-     * @param numberOfResults The maximum number of results to return, or null to use the backend default.
+     * @param numberOfResults The maximum number of results to return,
+     * or null to use the backend default.
      * @return A [SearchContactsResponse] containing the list of matched users.
      * @throws WireException If the request fails or an error occurs while searching.
      */

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -658,7 +658,7 @@ class WireApplicationManager internal constructor(
      * @param query The search string to match against user names and handles.
      * @param domain The domain to restrict the search to, or null to search across all domains.
      * @param numberOfResults The maximum number of results to return,
-     * or null to use the backend default.
+     * or null to use the SDK default.
      * @return A [SearchContactsResponse] containing the list of matched users.
      * @throws WireException If the request fails or an error occurs while searching.
      */

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -658,7 +658,7 @@ class WireApplicationManager internal constructor(
      * @param query The search string to match against user names and handles.
      * @param domain The domain to restrict the search to, or null to search across all domains.
      * @param numberOfResults The maximum number of results to return,
-     * or null to use the SDK default.
+     * or null to use the SDK default (15).
      * @return A [SearchContactsResponse] containing the list of matched users.
      * @throws WireException If the request fails or an error occurs while searching.
      */

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -662,6 +662,7 @@ class WireApplicationManager internal constructor(
      * @return A [SearchContactsResponse] containing the list of matched users.
      * @throws WireException If the request fails or an error occurs while searching.
      */
+    @JvmOverloads
     fun searchUsers(
         query: String,
         domain: String? = null,

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -656,7 +656,7 @@ class WireApplicationManager internal constructor(
      * Searches for Wire users matching the given query.
      *
      * @param query The search string to match against user names and handles.
-     * @param domain The domain to restrict the search to, or null to search across all domains.
+     * @param domain The domain to restrict the search to.
      * @param numberOfResults The maximum number of results to return,
      * or null to use the SDK default (15).
      * @return A [SearchContactsResponse] containing the list of matched users.
@@ -665,7 +665,7 @@ class WireApplicationManager internal constructor(
     @JvmOverloads
     fun searchUsers(
         query: String,
-        domain: String? = null,
+        domain: String,
         numberOfResults: Int? = null
     ): SearchContactsResponse {
         return runBlocking {
@@ -682,7 +682,7 @@ class WireApplicationManager internal constructor(
      */
     suspend fun searchUsersSuspending(
         query: String,
-        domain: String? = null,
+        domain: String,
         numberOfResults: Int? = null
     ): SearchContactsResponse {
         return searchApiClient.searchUsers(

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -653,7 +653,16 @@ class WireApplicationManager internal constructor(
     }
 
     /**
-     * Searches for Wire users matching the given query.
+     * Performs user search using a normalized version of the query.
+     *
+     * The search query is normalized by converting all characters to lower case
+     * and removing diacritical marks (for example, "Björn" becomes "bjorn").
+     *
+     * Matching users are returned according to the following priority order:
+     * 1. Users whose normalized full handle exactly matches the query
+     * 2. Users whose normalized full display name exactly matches the query
+     * 3. Users whose normalized handle starts with the query
+     * 4. Users whose normalized display name starts with the query
      *
      * @param query The search string to match against user names and handles.
      * @param domain The domain to restrict the search to.

--- a/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
@@ -1,0 +1,233 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.client
+
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SearchApiClientTest {
+    private fun apiClient(
+        responseBody: String = SEARCH_RESPONSE_EMPTY,
+        assertRequest: (io.ktor.client.request.HttpRequestData) -> Unit = {}
+    ) = SearchApiClient(createMockHttpClient(responseBody, assertRequest = assertRequest))
+
+    @Test
+    fun `when searchUsers, then correct URL path`() =
+        runTest {
+            var capturedPath: String? = null
+            apiClient { capturedPath = it.url.encodedPath }.searchUsers(query = "Alice")
+            assertEquals("/search/contacts", capturedPath)
+        }
+
+    @Test
+    fun `when searchUsers, then GET method`() =
+        runTest {
+            var capturedMethod: HttpMethod? = null
+            apiClient { capturedMethod = it.method }.searchUsers(query = "Alice")
+            assertEquals(HttpMethod.Get, capturedMethod)
+        }
+
+    @Test
+    fun `when searchUsers, then query parameter is set`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            assertEquals("Alice", capturedParams?.get("q"))
+        }
+
+    @Test
+    fun `when searchUsers with domain, then domain parameter is set`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(
+                query = "Alice",
+                domain = "wire.com"
+            )
+            assertEquals("wire.com", capturedParams?.get("domain"))
+        }
+
+    @Test
+    fun `when searchUsers without domain, then domain parameter is absent`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient {
+                capturedParams = it.url.parameters
+            }.searchUsers(query = "Alice", domain = null)
+            assertEquals(false, capturedParams?.contains("domain"))
+        }
+
+    @Test
+    fun `when searchUsers, then type parameter is always regular`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            assertEquals("regular", capturedParams?.get("type"))
+        }
+
+    @Test
+    fun `when searchUsers with custom numberOfResults, then size parameter is set`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(
+                query = "Alice",
+                numberOfResults = 42
+            )
+            assertEquals("42", capturedParams?.get("size"))
+        }
+
+    @Test
+    fun `when searchUsers with default numberOfResults, then size parameter is 15`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            assertEquals("15", capturedParams?.get("size"))
+        }
+
+    @Test
+    fun `given blank query, when searchUsers, then throws IAException`() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> {
+                apiClient().searchUsers(query = "   ")
+            }
+        }
+
+    @Test
+    fun `given empty query, when searchUsers, then throws IAException`() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> {
+                apiClient().searchUsers(query = "")
+            }
+        }
+
+    @Test
+    fun `given numberOfResults below minimum, when searchUsers, then throws IAException`() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> {
+                apiClient().searchUsers(query = "Alice", numberOfResults = 0)
+            }
+        }
+
+    @Test
+    fun `given numberOfResults above maximum, when searchUsers, then throws IAException`() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> {
+                apiClient().searchUsers(query = "Alice", numberOfResults = 501)
+            }
+        }
+
+    @Test
+    fun `given numberOfResults at minimum boundary, when searchUsers, then succeeds`() =
+        runTest {
+            apiClient().searchUsers(query = "Alice", numberOfResults = 1)
+        }
+
+    @Test
+    fun `given numberOfResults at maximum boundary, when searchUsers, then succeeds`() =
+        runTest {
+            apiClient().searchUsers(query = "Alice", numberOfResults = 500)
+        }
+
+    @Test
+    fun `given documents in response, when searchUsers, then documents deserialized`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            assertEquals(1, result.documents.size)
+            assertEquals("Alice", result.documents.first().name)
+            assertEquals("alice", result.documents.first().handle)
+        }
+
+    @Test
+    fun `given document with qualifiedId, when searchUsers, then qualifiedId deserialized`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            assertEquals("wire.com", result.documents.first().qualifiedId?.domain)
+            assertEquals(UUID.fromString(USER_ID), result.documents.first().qualifiedId?.id)
+        }
+
+    @Test
+    fun `given hasMore true in response, when searchUsers, then hasMore is true`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            assertEquals(true, result.hasMore)
+        }
+
+    @Test
+    fun `given empty documents in response, when searchUsers, then documents list is empty`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_EMPTY).searchUsers(query = "Alice")
+            assertEquals(0, result.documents.size)
+        }
+
+    @Test
+    fun `given pagingState in response, when searchUsers, then pagingState deserialized`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            assertEquals("next-page-token", result.pagingState)
+        }
+
+    @Test
+    fun `given null pagingState in response, when searchUsers, then pagingState is null`() =
+        runTest {
+            val result = apiClient(SEARCH_RESPONSE_EMPTY).searchUsers(query = "Alice")
+            assertEquals(null, result.pagingState)
+        }
+
+    companion object {
+        private const val USER_ID = "99db9768-04e3-4b5d-9268-831b6a25c4ab"
+
+        private val SEARCH_RESPONSE_EMPTY = """
+            {
+              "documents": [],
+              "found": 0,
+              "has_more": false,
+              "paging_state": null,
+              "returned": 0,
+              "search_policy": "full_search",
+              "took": 5
+            }
+        """.trimIndent()
+
+        private val SEARCH_RESPONSE_WITH_RESULTS = """
+            {
+              "documents": [
+                {
+                  "accent_id": 1,
+                  "handle": "alice",
+                  "id": "$USER_ID",
+                  "name": "Alice",
+                  "qualified_id": {
+                    "domain": "wire.com",
+                    "id": "$USER_ID"
+                  },
+                  "team": null,
+                  "type": "regular"
+                }
+              ],
+              "found": 1,
+              "has_more": true,
+              "paging_state": "next-page-token",
+              "returned": 1,
+              "search_policy": "full_search",
+              "took": 12
+            }
+        """.trimIndent()
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
@@ -54,6 +54,17 @@ class SearchApiClientTest {
         }
 
     @Test
+    fun `when searchUsers with null numberOfResults, then size parameter is 15`() =
+        runTest {
+            var capturedParams: io.ktor.http.Parameters? = null
+            apiClient { capturedParams = it.url.parameters }.searchUsers(
+                query = "Alice",
+                numberOfResults = null
+            )
+            assertEquals("15", capturedParams?.get("size"))
+        }
+
+    @Test
     fun `when searchUsers with domain, then domain parameter is set`() =
         runTest {
             var capturedParams: io.ktor.http.Parameters? = null

--- a/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
@@ -33,7 +33,9 @@ class SearchApiClientTest {
     fun `when searchUsers, then correct URL path`() =
         runTest {
             var capturedPath: String? = null
-            apiClient { capturedPath = it.url.encodedPath }.searchUsers(query = "Alice")
+            apiClient {
+                capturedPath = it.url.encodedPath
+            }.searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("/search/contacts", capturedPath)
         }
 
@@ -41,7 +43,9 @@ class SearchApiClientTest {
     fun `when searchUsers, then GET method`() =
         runTest {
             var capturedMethod: HttpMethod? = null
-            apiClient { capturedMethod = it.method }.searchUsers(query = "Alice")
+            apiClient {
+                capturedMethod = it.method
+            }.searchUsers(query = "Alice", domain = "wire.com")
             assertEquals(HttpMethod.Get, capturedMethod)
         }
 
@@ -49,7 +53,9 @@ class SearchApiClientTest {
     fun `when searchUsers, then query parameter is set`() =
         runTest {
             var capturedParams: io.ktor.http.Parameters? = null
-            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            apiClient {
+                capturedParams = it.url.parameters
+            }.searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("Alice", capturedParams?.get("q"))
         }
 
@@ -59,6 +65,7 @@ class SearchApiClientTest {
             var capturedParams: io.ktor.http.Parameters? = null
             apiClient { capturedParams = it.url.parameters }.searchUsers(
                 query = "Alice",
+                domain = "wire.com",
                 numberOfResults = null
             )
             assertEquals("15", capturedParams?.get("size"))
@@ -76,20 +83,20 @@ class SearchApiClientTest {
         }
 
     @Test
-    fun `when searchUsers without domain, then domain parameter is absent`() =
+    fun `given blank domain, when searchUsers, then throws IAException`() =
         runTest {
-            var capturedParams: io.ktor.http.Parameters? = null
-            apiClient {
-                capturedParams = it.url.parameters
-            }.searchUsers(query = "Alice", domain = null)
-            assertEquals(false, capturedParams?.contains("domain"))
+            assertFailsWith<IllegalArgumentException> {
+                apiClient().searchUsers(query = "Alice", domain = "   ")
+            }
         }
 
     @Test
     fun `when searchUsers, then type parameter is always regular`() =
         runTest {
             var capturedParams: io.ktor.http.Parameters? = null
-            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            apiClient {
+                capturedParams = it.url.parameters
+            }.searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("regular", capturedParams?.get("type"))
         }
 
@@ -99,6 +106,7 @@ class SearchApiClientTest {
             var capturedParams: io.ktor.http.Parameters? = null
             apiClient { capturedParams = it.url.parameters }.searchUsers(
                 query = "Alice",
+                domain = "wire.com",
                 numberOfResults = 42
             )
             assertEquals("42", capturedParams?.get("size"))
@@ -108,7 +116,9 @@ class SearchApiClientTest {
     fun `when searchUsers with default numberOfResults, then size parameter is 15`() =
         runTest {
             var capturedParams: io.ktor.http.Parameters? = null
-            apiClient { capturedParams = it.url.parameters }.searchUsers(query = "Alice")
+            apiClient {
+                capturedParams = it.url.parameters
+            }.searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("15", capturedParams?.get("size"))
         }
 
@@ -116,7 +126,7 @@ class SearchApiClientTest {
     fun `given blank query, when searchUsers, then throws IAException`() =
         runTest {
             assertFailsWith<IllegalArgumentException> {
-                apiClient().searchUsers(query = "   ")
+                apiClient().searchUsers(query = "   ", domain = "wire.com")
             }
         }
 
@@ -124,7 +134,7 @@ class SearchApiClientTest {
     fun `given empty query, when searchUsers, then throws IAException`() =
         runTest {
             assertFailsWith<IllegalArgumentException> {
-                apiClient().searchUsers(query = "")
+                apiClient().searchUsers(query = "", domain = "wire.com")
             }
         }
 
@@ -132,7 +142,7 @@ class SearchApiClientTest {
     fun `given numberOfResults below minimum, when searchUsers, then throws IAException`() =
         runTest {
             assertFailsWith<IllegalArgumentException> {
-                apiClient().searchUsers(query = "Alice", numberOfResults = 0)
+                apiClient().searchUsers(query = "Alice", domain = "wire.com", numberOfResults = 0)
             }
         }
 
@@ -140,26 +150,28 @@ class SearchApiClientTest {
     fun `given numberOfResults above maximum, when searchUsers, then throws IAException`() =
         runTest {
             assertFailsWith<IllegalArgumentException> {
-                apiClient().searchUsers(query = "Alice", numberOfResults = 501)
+                apiClient().searchUsers(query = "Alice", domain = "wire.com", numberOfResults = 501)
             }
         }
 
     @Test
     fun `given numberOfResults at minimum boundary, when searchUsers, then succeeds`() =
         runTest {
-            apiClient().searchUsers(query = "Alice", numberOfResults = 1)
+            apiClient().searchUsers(query = "Alice", domain = "wire.com", numberOfResults = 1)
         }
 
     @Test
     fun `given numberOfResults at maximum boundary, when searchUsers, then succeeds`() =
         runTest {
-            apiClient().searchUsers(query = "Alice", numberOfResults = 500)
+            apiClient().searchUsers(query = "Alice", domain = "wire.com", numberOfResults = 500)
         }
 
     @Test
     fun `given documents in response, when searchUsers, then documents deserialized`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_WITH_RESULTS
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals(1, result.documents.size)
             assertEquals("Alice", result.documents.first().name)
             assertEquals("alice", result.documents.first().handle)
@@ -168,7 +180,9 @@ class SearchApiClientTest {
     @Test
     fun `given document with qualifiedId, when searchUsers, then qualifiedId deserialized`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_WITH_RESULTS
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("wire.com", result.documents.first().qualifiedId?.domain)
             assertEquals(UUID.fromString(USER_ID), result.documents.first().qualifiedId?.id)
         }
@@ -176,28 +190,36 @@ class SearchApiClientTest {
     @Test
     fun `given hasMore true in response, when searchUsers, then hasMore is true`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_WITH_RESULTS
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals(true, result.hasMore)
         }
 
     @Test
     fun `given empty documents in response, when searchUsers, then documents list is empty`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_EMPTY).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_EMPTY
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals(0, result.documents.size)
         }
 
     @Test
     fun `given pagingState in response, when searchUsers, then pagingState deserialized`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_WITH_RESULTS).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_WITH_RESULTS
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals("next-page-token", result.pagingState)
         }
 
     @Test
     fun `given null pagingState in response, when searchUsers, then pagingState is null`() =
         runTest {
-            val result = apiClient(SEARCH_RESPONSE_EMPTY).searchUsers(query = "Alice")
+            val result = apiClient(
+                SEARCH_RESPONSE_EMPTY
+            ).searchUsers(query = "Alice", domain = "wire.com")
             assertEquals(null, result.pagingState)
         }
 

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -26,6 +26,7 @@ import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
+import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
@@ -37,6 +38,7 @@ import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.WireMessage
 import com.wire.sdk.model.http.conversation.ConversationRole
+import com.wire.sdk.model.http.search.SearchContactsResponse
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
@@ -353,6 +355,7 @@ class WireApplicationManagerTest {
 
             val usersApiClient = mockk<UsersApiClient>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(1, 2, 3)
@@ -366,6 +369,7 @@ class WireApplicationManagerTest {
                 usersApiClient = usersApiClient,
                 mlsApiClient = mlsApiClient,
                 assetsApiClient = assetsApiClient,
+                searchApiClient = searchApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
                 conversationService = conversationService
@@ -430,6 +434,7 @@ class WireApplicationManagerTest {
 
             val usersApiClient = mockk<UsersApiClient>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(2)
@@ -442,6 +447,7 @@ class WireApplicationManagerTest {
                 backendClient = backendClient,
                 usersApiClient = usersApiClient,
                 assetsApiClient = assetsApiClient,
+                searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
@@ -506,6 +512,7 @@ class WireApplicationManagerTest {
             val backendClient = mockk<BackendClient>(relaxed = true)
             val usersApiClient = mockk<UsersApiClient>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
@@ -516,6 +523,7 @@ class WireApplicationManagerTest {
                 backendClient = backendClient,
                 usersApiClient = usersApiClient,
                 assetsApiClient = assetsApiClient,
+                searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
@@ -537,6 +545,97 @@ class WireApplicationManagerTest {
             // Act & Assert
             assertThrows<WireException.InvalidParameter> {
                 manager.sendMessageSuspending(reaction)
+            }
+        }
+
+    @Test
+    fun `when searchUsers, then delegates to searchApiClient with correct parameters`() =
+        runTest {
+            // Arrange
+            val conversationService = mockk<ConversationService>(relaxed = true)
+            val backendClient = mockk<BackendClient>(relaxed = true)
+            val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
+            val cryptoClient = mockk<CryptoClient>(relaxed = true)
+            val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
+            val teamStorage = mockk<TeamStorage>(relaxed = true)
+
+            val expectedResponse = SEARCH_CONTACTS_RESPONSE
+            coEvery {
+                searchApiClient.searchUsers(
+                    query = SEARCH_QUERY,
+                    domain = SEARCH_DOMAIN,
+                    numberOfResults = SEARCH_NUMBER_OF_RESULTS
+                )
+            } returns expectedResponse
+
+            val manager = WireApplicationManager(
+                teamStorage = teamStorage,
+                backendClient = backendClient,
+                usersApiClient = usersApiClient,
+                mlsApiClient = mlsApiClient,
+                assetsApiClient = assetsApiClient,
+                searchApiClient = searchApiClient,
+                cryptoClient = cryptoClient,
+                mlsFallbackStrategy = mlsFallbackStrategy,
+                conversationService = conversationService
+            )
+
+            // Act
+            val result = manager.searchUsersSuspending(
+                queryFor = SEARCH_QUERY,
+                domain = SEARCH_DOMAIN,
+                numberOfResults = SEARCH_NUMBER_OF_RESULTS
+            )
+
+            // Assert
+            assertEquals(expectedResponse, result)
+            coVerify(exactly = 1) {
+                searchApiClient.searchUsers(
+                    query = SEARCH_QUERY,
+                    domain = SEARCH_DOMAIN,
+                    numberOfResults = SEARCH_NUMBER_OF_RESULTS
+                )
+            }
+        }
+
+    @Test
+    fun `when searchUsers without optional parameters, then delegates with nulls`() =
+        runTest {
+            // Arrange
+            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
+            coEvery {
+                searchApiClient.searchUsers(
+                    query = SEARCH_QUERY,
+                    domain = null,
+                    numberOfResults = null
+                )
+            } returns SEARCH_CONTACTS_RESPONSE
+
+            val manager = WireApplicationManager(
+                teamStorage = mockk(relaxed = true),
+                backendClient = mockk(relaxed = true),
+                usersApiClient = mockk(relaxed = true),
+                mlsApiClient = mockk(relaxed = true),
+                assetsApiClient = mockk(relaxed = true),
+                searchApiClient = searchApiClient,
+                cryptoClient = mockk(relaxed = true),
+                mlsFallbackStrategy = mockk(relaxed = true),
+                conversationService = mockk(relaxed = true)
+            )
+
+            // Act
+            manager.searchUsersSuspending(queryFor = SEARCH_QUERY)
+
+            // Assert
+            coVerify(exactly = 1) {
+                searchApiClient.searchUsers(
+                    query = SEARCH_QUERY,
+                    domain = null,
+                    numberOfResults = null
+                )
             }
         }
 
@@ -721,6 +820,18 @@ class WireApplicationManagerTest {
               "name": "SDK User"
             }
             """.trimIndent()
+
+        private const val SEARCH_QUERY = "Alice"
+        private const val SEARCH_DOMAIN = "wire.com"
+        private const val SEARCH_NUMBER_OF_RESULTS = 25
+        private val SEARCH_CONTACTS_RESPONSE = SearchContactsResponse(
+            documents = emptyList(),
+            found = 0,
+            hasMore = false,
+            pagingState = null,
+            returned = 0,
+            took = 5
+        )
 
         @JvmStatic
         @BeforeAll

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -585,7 +585,7 @@ class WireApplicationManagerTest {
 
             // Act
             val result = manager.searchUsersSuspending(
-                queryFor = SEARCH_QUERY,
+                query = SEARCH_QUERY,
                 domain = SEARCH_DOMAIN,
                 numberOfResults = SEARCH_NUMBER_OF_RESULTS
             )
@@ -627,7 +627,7 @@ class WireApplicationManagerTest {
             )
 
             // Act
-            manager.searchUsersSuspending(queryFor = SEARCH_QUERY)
+            manager.searchUsersSuspending(query = SEARCH_QUERY)
 
             // Assert
             coVerify(exactly = 1) {

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -601,44 +601,6 @@ class WireApplicationManagerTest {
             }
         }
 
-    @Test
-    fun `when searchUsers without optional parameters, then delegates with nulls`() =
-        runTest {
-            // Arrange
-            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
-            coEvery {
-                searchApiClient.searchUsers(
-                    query = SEARCH_QUERY,
-                    domain = null,
-                    numberOfResults = null
-                )
-            } returns SEARCH_CONTACTS_RESPONSE
-
-            val manager = WireApplicationManager(
-                teamStorage = mockk(relaxed = true),
-                backendClient = mockk(relaxed = true),
-                usersApiClient = mockk(relaxed = true),
-                mlsApiClient = mockk(relaxed = true),
-                assetsApiClient = mockk(relaxed = true),
-                searchApiClient = searchApiClient,
-                cryptoClient = mockk(relaxed = true),
-                mlsFallbackStrategy = mockk(relaxed = true),
-                conversationService = mockk(relaxed = true)
-            )
-
-            // Act
-            manager.searchUsersSuspending(query = SEARCH_QUERY)
-
-            // Assert
-            coVerify(exactly = 1) {
-                searchApiClient.searchUsers(
-                    query = SEARCH_QUERY,
-                    domain = null,
-                    numberOfResults = null
-                )
-            }
-        }
-
     private suspend fun generateUser2Packages(): List<KeyPackage> =
         MlsCryptoClient.create(
             appId = USER_2.id,

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
@@ -61,10 +61,6 @@ public class CustomWireEventsHandler extends WireEventsHandlerDefault {
 
         // ___ Case-3: Normal text message
 
-        System.out.println("heey1");
-        System.out.println(getManager().searchContacts());
-        System.out.println("heey2");
-
         // Send read receipt
         final var readReceipt = WireMessage.Receipt.create(
                 wireMessage.conversationId(),

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
@@ -61,6 +61,10 @@ public class CustomWireEventsHandler extends WireEventsHandlerDefault {
 
         // ___ Case-3: Normal text message
 
+        System.out.println("heey1");
+        System.out.println(getManager().searchContacts());
+        System.out.println("heey2");
+
         // Send read receipt
         final var readReceipt = WireMessage.Receipt.create(
                 wireMessage.conversationId(),

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
@@ -27,7 +27,8 @@ public enum TestCommand {
     ASSET_IMAGE("asset-image"),
     ASSET_AUDIO("asset-audio"),
     ASSET_VIDEO("asset-video"),
-    ASSET_PDF_DOCUMENT("asset-document-pdf");
+    ASSET_PDF_DOCUMENT("asset-document-pdf"),
+    SEARCH_USER("search-user");
 
     private final String commandStr;
 

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -51,6 +51,7 @@ class TestCommandProcessor {
             case ASSET_AUDIO -> processAssetAudio(wireMessage);
             case ASSET_VIDEO -> processAssetVideo(wireMessage);
             case ASSET_PDF_DOCUMENT -> replyWithSamplePDFDocument(wireMessage);
+            case SEARCH_USER -> processSearchUser(wireMessage);
         }
     }
 
@@ -232,6 +233,50 @@ class TestCommandProcessor {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void processSearchUser(WireMessage.Text wireMessage) {
+        // Expected message: `search-user [queryString]`
+        final var split = wireMessage.text().split(" ", 2);
+        if (split.length < 2 || split[1].isBlank()) {
+            this.manager.sendMessage(WireMessage.Text.create(
+                    wireMessage.conversationId(),
+                    "⚠️ Usage: search-user [queryString]  (Exp: search-user alex)",
+                    List.of(), List.of(), null)
+            );
+
+            return;
+        }
+
+        final var query = split[1].trim();
+        final var response = this.manager.searchUsers(query, wireMessage.sender().domain(), 100);
+
+        final var sb = new StringBuilder();
+        sb.append("Search results for \"").append(query).append("\" ")
+                .append("(").append(response.getReturned() != null ? response.getReturned() : 0)
+                .append(" of ").append(response.getFound() != null ? response.getFound() : "?")
+                .append(" found):\n\n");
+
+        if (response.getDocuments().isEmpty()) {
+            sb.append("No users found.");
+        } else {
+            for (final var doc : response.getDocuments()) {
+                sb.append("👉").append(doc.getName());
+                if (doc.getHandle() != null) {
+                    sb.append(" (@").append(doc.getHandle()).append(")");
+                }
+                if (doc.getQualifiedId() != null) {
+                    sb.append(", ID: ").append("`").append(doc.getQualifiedId().id()).append("`")
+                            .append(" @ ").append(doc.getQualifiedId().domain());
+                }
+                sb.append("\n");
+            }
+        }
+
+        this.manager.sendMessage(WireMessage.Text.create(
+                wireMessage.conversationId(),
+                sb.toString(),
+                List.of(), List.of(), null));
     }
 
 }

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -268,6 +268,7 @@ class TestCommandProcessor {
                 if (doc.getQualifiedId() != null) {
                     sb.append(", ID: ").append("`").append(doc.getQualifiedId().id()).append("`")
                             .append(" @ ").append(doc.getQualifiedId().domain());
+                    sb.append(", team: ").append(doc.getTeam());
                 }
                 sb.append("\n");
             }

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -268,8 +268,8 @@ class TestCommandProcessor {
                 if (doc.getQualifiedId() != null) {
                     sb.append(", ID: ").append("`").append(doc.getQualifiedId().id()).append("`")
                             .append(" @ ").append(doc.getQualifiedId().domain());
-                    sb.append(", team: ").append(doc.getTeam());
                 }
+                sb.append(", team: ").append(doc.getTeam());
                 sb.append("\n");
             }
         }

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -241,7 +241,7 @@ class TestCommandProcessor {
         if (split.length < 2 || split[1].isBlank()) {
             this.manager.sendMessage(WireMessage.Text.create(
                     wireMessage.conversationId(),
-                    "⚠️ Usage: search-user [queryString]  (Exp: search-user alex)",
+                    "⚠️ Usage: search-user [queryString]  (e.g. search-user alex)",
                     List.of(), List.of(), null)
             );
 
@@ -254,7 +254,7 @@ class TestCommandProcessor {
         final var sb = new StringBuilder();
         sb.append("Search results for \"").append(query).append("\" ")
                 .append("(").append(response.getReturned() != null ? response.getReturned() : 0)
-                .append(" of ").append(response.getFound() != null ? response.getFound() : "?")
+                .append(" of ").append(response.getFound() != null ? response.getFound() : 0)
                 .append(" found):\n\n");
 
         if (response.getDocuments().isEmpty()) {

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -89,6 +89,11 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
             return
         }
 
+        if (isSearchUser(text = wireMessage.text)) {
+            processSearchUser(wireMessage = wireMessage)
+            return
+        }
+
         // Sends an Ephemeral message if received message is Ephemeral
         wireMessage.expiresAfterMillis?.let {
             val ephemeralMessage = WireMessage.Text.create(
@@ -222,6 +227,9 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
 
     private fun isAssetPDFDocumentTestMessage(text: String): Boolean =
         text.startsWith("asset-document-pdf")
+
+    private fun isSearchUser(text: String): Boolean =
+        text.startsWith("search-user")
 
     private suspend fun processAddMembersToConversation(wireMessage: WireMessage.Text) {
         // Expected message: `add-members-to-conversation [USER_ID] [DOMAIN]
@@ -375,6 +383,52 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
             name = asset.name,
             mimeType = "video/mp4",
             retention = AssetRetention.VOLATILE
+        )
+    }
+
+    private suspend fun processSearchUser(wireMessage: WireMessage.Text) {
+        // Expected message: `search-user [queryString]`
+        val split = wireMessage.text.split(" ", limit = 2)
+        if (split.size < 2 || split[1].isBlank()) {
+            manager.sendMessageSuspending(
+                WireMessage.Text.create(
+                    conversationId = wireMessage.conversationId,
+                    text = "⚠️ Usage: search-user [queryString]  (Exp: search-user alex)"
+                )
+            )
+            return
+        }
+
+        val query = split[1].trim()
+        val response = manager.searchUsersSuspending(
+            queryFor = query,
+            domain = wireMessage.sender.domain,
+            numberOfResults = 100
+        )
+
+        val sb = StringBuilder()
+        sb.append("Search results for \"$query\" ")
+            .append("(${response.returned ?: 0} of ${response.found ?: "?"} found):\n\n")
+
+        if (response.documents.isEmpty()) {
+            sb.append("No users found.")
+        } else {
+            response.documents.forEach { doc ->
+                sb.append("👉 ${doc.name}")
+                doc.handle?.let { sb.append(" (@$it)") }
+                doc.qualifiedId?.let {
+                    sb.append(", ID: `${it.id}` @ ${it.domain}")
+                }
+                doc.team?.let { sb.append(", team: $it") }
+                sb.append("\n")
+            }
+        }
+
+        manager.sendMessageSuspending(
+            WireMessage.Text.create(
+                conversationId = wireMessage.conversationId,
+                text = sb.toString()
+            )
         )
     }
 

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -401,7 +401,7 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
 
         val query = split[1].trim()
         val response = manager.searchUsersSuspending(
-            queryFor = query,
+            query = query,
             domain = wireMessage.sender.domain,
             numberOfResults = 100
         )

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -393,7 +393,7 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
             manager.sendMessageSuspending(
                 WireMessage.Text.create(
                     conversationId = wireMessage.conversationId,
-                    text = "⚠️ Usage: search-user [queryString]  (Exp: search-user alex)"
+                    text = "⚠️ Usage: search-user [queryString]  (e.g. search-user alex)"
                 )
             )
             return


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Developers wants to be able to search users by name, handle.  

### Solutions
Implement the flow by using `/search/contacts` endpoint.

### Testing
#### How to Test
1. Run Java/Kotlin sample, type search-user [query] command and send it. you will see the simplified response on the UI.
2. Check the logs and make sure about the correctness of the endpoint together with parameters set.