### PR TITLE
chore: WPB-25312 Refactor method naming in CoreCryto service and client layer

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/CryptoClient.kt
@@ -80,16 +80,16 @@ internal interface CryptoClient : AutoCloseable {
     suspend fun updateKeyingMaterial(mlsGroupId: ConversationId)
 
     /**
-     * Alternative way to add a member to an MLS conversation.
+     * Alternative way to add members (clients) to an MLS conversation.
      * Instead of creating a join request accepted by the new client,
-     * this method directly adds a member to a conversation.
+     * this method directly adds members (clients) to a conversation.
      */
-    suspend fun addMemberToMlsConversation(
+    suspend fun addClientsToMlsConversation(
         mlsGroupId: ConversationId,
         keyPackages: List<KeyPackage>
     )
 
-    suspend fun removeMembersFromConversation(
+    suspend fun removeClientsFromConversation(
         mlsGroupId: ConversationId,
         clientIds: List<CryptoClientId>
     )

--- a/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
@@ -205,26 +205,32 @@ internal class MlsCryptoClient private constructor(
         }
     }
 
-    override suspend fun addMemberToMlsConversation(
+    override suspend fun addClientsToMlsConversation(
         mlsGroupId: ConversationId,
         keyPackages: List<KeyPackage>
     ) {
         coreCryptoClient.transaction {
+            logger.debug("Clients will be added to conversation. mlsGroupId: {}", mlsGroupId)
             it.addClientsToConversation(mlsGroupId, keyPackages)
+            logger.debug("Clients are added to conversation. mlsGroupId: {}", mlsGroupId)
         }
     }
 
-    override suspend fun removeMembersFromConversation(
+    override suspend fun removeClientsFromConversation(
         mlsGroupId: ConversationId,
         clientIds: List<CryptoClientId>
     ) {
         coreCryptoClient.transaction {
+            logger.debug("Clients will be removed from conversation. mlsGroupId: {}", mlsGroupId)
+
             it.removeClientsFromConversation(
                 conversationId = mlsGroupId,
                 clients = clientIds.map { client ->
                     ClientId(client.value.toByteArray())
                 }
             )
+
+            logger.debug("Clients are removed from conversation. mlsGroupId: {}", mlsGroupId)
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
@@ -248,7 +248,7 @@ internal class ConversationService internal constructor(
         if (claimedKeyPackagesResult.keyPackages.isEmpty()) {
             cryptoClient.updateKeyingMaterial(mlsGroupId)
         } else {
-            cryptoClient.addMemberToMlsConversation(
+            cryptoClient.addClientsToMlsConversation(
                 mlsGroupId = mlsGroupId,
                 keyPackages = claimedKeyPackagesResult.keyPackages.map { keyPackage ->
                     keyPackage.toMLSKeyPackage()
@@ -666,7 +666,7 @@ internal class ConversationService internal constructor(
         )
 
         try {
-            cryptoClient.addMemberToMlsConversation(
+            cryptoClient.addClientsToMlsConversation(
                 mlsGroupId = conversation.mlsGroupId,
                 keyPackages = claimedKeyPackagesResult.keyPackages.map { keyPackage ->
                     keyPackage.toMLSKeyPackage()
@@ -740,7 +740,7 @@ internal class ConversationService internal constructor(
             conversationId
         )
 
-        cryptoClient.removeMembersFromConversation(
+        cryptoClient.removeClientsFromConversation(
             mlsGroupId = conversation.mlsGroupId,
             clientIds = clients
         )

--- a/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
@@ -161,7 +161,7 @@ class MlsCryptoClientTest {
             assertFalse { aliceClient.conversationExists(mlsGroupId) }
 
             assertNotEquals(bobClient.mlsGetPublicKey(), aliceClient.mlsGetPublicKey())
-            bobClient.addMemberToMlsConversation(mlsGroupId, keyPackages)
+            bobClient.addClientsToMlsConversation(mlsGroupId, keyPackages)
 
             // Alice accepts joining the conversation
             val welcomeMessage = testMlsTransport.getLastWelcome()

--- a/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
@@ -679,7 +679,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    addMemberToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    addClientsToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } returns Unit
             }
 
@@ -705,7 +705,7 @@ class ConversationServiceTest {
             assertEquals(0, result.failedUsers.size)
 
             coVerify(exactly = 1) {
-                cryptoClient.addMemberToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
+                cryptoClient.addClientsToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
             }
             verify(exactly = 1) {
                 conversationStorage.saveMembers(CONVERSATION_ID, any())
@@ -897,7 +897,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    addMemberToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    addClientsToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } throws MlsException.Other("Failed to add member")
             }
 
@@ -922,7 +922,7 @@ class ConversationServiceTest {
             }
 
             coVerify(exactly = 1) {
-                cryptoClient.addMemberToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
+                cryptoClient.addClientsToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
             }
             verify(exactly = 0) {
                 conversationStorage.saveMembers(any(), any())
@@ -986,7 +986,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    addMemberToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    addClientsToMlsConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } returns Unit
             }
 
@@ -1047,7 +1047,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    removeMembersFromConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    removeClientsFromConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } returns Unit
             }
 
@@ -1068,7 +1068,7 @@ class ConversationServiceTest {
 
             coVerify(exactly = 1) {
                 usersApiClient.getClientsByUserId(CONVERSATION_MEMBER_1)
-                cryptoClient.removeMembersFromConversation(CONVERSATION_MLS_GROUP_ID, any())
+                cryptoClient.removeClientsFromConversation(CONVERSATION_MLS_GROUP_ID, any())
             }
             verify(exactly = 1) {
                 conversationStorage.deleteMembers(CONVERSATION_ID, membersToRemove)
@@ -1113,7 +1113,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    removeMembersFromConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    removeClientsFromConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } returns Unit
             }
 
@@ -1134,7 +1134,7 @@ class ConversationServiceTest {
 
             coVerify(exactly = 1) {
                 usersApiClient.getClientsByUserIds(membersToRemove)
-                cryptoClient.removeMembersFromConversation(CONVERSATION_MLS_GROUP_ID, any())
+                cryptoClient.removeClientsFromConversation(CONVERSATION_MLS_GROUP_ID, any())
             }
             coVerify(exactly = 0) {
                 usersApiClient.getClientsByUserId(any())
@@ -1278,7 +1278,7 @@ class ConversationServiceTest {
 
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    removeMembersFromConversation(CONVERSATION_MLS_GROUP_ID, any())
+                    removeClientsFromConversation(CONVERSATION_MLS_GROUP_ID, any())
                 } throws MlsException.Other("Failed to remove members")
             }
 
@@ -1303,7 +1303,7 @@ class ConversationServiceTest {
             }
 
             coVerify(exactly = 1) {
-                cryptoClient.removeMembersFromConversation(
+                cryptoClient.removeClientsFromConversation(
                     mlsGroupId = CONVERSATION_MLS_GROUP_ID,
                     clientIds = listOf(client1).map { client ->
                         CryptoClientId.create(
@@ -1359,7 +1359,7 @@ class ConversationServiceTest {
             val capturedClients = slot<List<CryptoClientId>>()
             val cryptoClient = mockk<CryptoClient> {
                 coEvery {
-                    removeMembersFromConversation(
+                    removeClientsFromConversation(
                         mlsGroupId = CONVERSATION_MLS_GROUP_ID,
                         clientIds = capture(lst = capturedClients)
                     )
@@ -1385,7 +1385,7 @@ class ConversationServiceTest {
 
             coVerify(exactly = 1) {
                 usersApiClient.getClientsByUserId(CONVERSATION_MEMBER_1)
-                cryptoClient.removeMembersFromConversation(
+                cryptoClient.removeClientsFromConversation(
                     mlsGroupId = CONVERSATION_MLS_GROUP_ID,
                     clientIds = listOf(client1, client2, client3).map { client ->
                         CryptoClientId.create(
@@ -1431,7 +1431,7 @@ class ConversationServiceTest {
             val cryptoClient = mockk<CryptoClient> {
                 coEvery { conversationExists(any()) } returns false
                 coEvery { createConversation(any(), any()) } returns Unit
-                coEvery { addMemberToMlsConversation(any(), any()) } returns Unit
+                coEvery { addClientsToMlsConversation(any(), any()) } returns Unit
             }
 
             val service = ConversationService(
@@ -1534,7 +1534,7 @@ class ConversationServiceTest {
                 // Not in crypto → proceed with full establishment
                 coEvery { conversationExists(any()) } returns false
                 coEvery { createConversation(any(), any()) } returns Unit
-                coEvery { addMemberToMlsConversation(any(), any()) } returns Unit
+                coEvery { addClientsToMlsConversation(any(), any()) } returns Unit
             }
 
             val service = ConversationService(
@@ -1604,7 +1604,7 @@ class ConversationServiceTest {
             service.createOneToOne(CONVERSATION_MEMBER_1)
 
             coVerify(exactly = 0) { cryptoClient.createConversation(any(), any()) }
-            coVerify(exactly = 0) { cryptoClient.addMemberToMlsConversation(any(), any()) }
+            coVerify(exactly = 0) { cryptoClient.addClientsToMlsConversation(any(), any()) }
             verify(exactly = 1) { conversationStorage.save(any()) }
         }
 

--- a/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
@@ -131,7 +131,7 @@ internal class MockCoreCryptoClient private constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun addMemberToMlsConversation(
+    override suspend fun addClientsToMlsConversation(
         mlsGroupId: ConversationId,
         keyPackages: List<KeyPackage>
     ) {
@@ -149,7 +149,7 @@ internal class MockCoreCryptoClient private constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun removeMembersFromConversation(
+    override suspend fun removeClientsFromConversation(
         mlsGroupId: ConversationId,
         clientIds: List<CryptoClientId>
     ) {


### PR DESCRIPTION
The correct wording in CoreCrypto layers is using "client" instead of "member" since in this layer we add/remove clients actually. This is fixed now.