### PR TITLE
feat: Handle conversation.mls-reset event #WPB-25075

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
@@ -23,6 +23,7 @@ import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.CryptoClientId
 import com.wire.sdk.model.http.MlsPublicKeys
 import com.wire.sdk.model.http.client.PreKeyCrypto
+import com.wire.sdk.utils.obfuscateId
 import io.ktor.util.encodeBase64
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -260,10 +261,16 @@ internal class MlsCryptoClient private constructor(
         }
 
     override suspend fun wipeConversation(mlsGroupId: ConversationId) {
-        logger.debug("Conversation will be deleted from CoreCrypto. mlsGroupId: {}", mlsGroupId)
+        logger.debug(
+            "Conversation will be deleted from CoreCrypto. mlsGroupId: {}",
+            mlsGroupId.toString().obfuscateId()
+        )
         coreCryptoClient.transaction {
             it.wipeConversation(mlsGroupId)
-            logger.debug("Conversation is deleted from CoreCrypto. mlsGroupId: {}", mlsGroupId)
+            logger.debug(
+                "Conversation is deleted from CoreCrypto. mlsGroupId: {}",
+                mlsGroupId.toString().obfuscateId()
+            )
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/EventResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/EventResponse.kt
@@ -133,6 +133,15 @@ sealed class EventContentDTO {
             @SerialName("time") override val time: Instant,
             @SerialName("data") override val data: MessageTimerUpdateEventData
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.mls-reset")
+        data class MlsReset(
+            @SerialName("qualified_conversation") override val qualifiedConversation: QualifiedId,
+            @SerialName("qualified_from") override val qualifiedFrom: QualifiedId,
+            @SerialName("time") override val time: Instant,
+            @SerialName("data") override val data: MlsConversationResetData
+        ) : Conversation()
     }
 
     @Serializable
@@ -142,5 +151,11 @@ sealed class EventContentDTO {
     @Serializable
     data class MessageTimerUpdateEventData(
         @SerialName("message_timer") val messageTimer: Long?
+    )
+
+    @Serializable
+    data class MlsConversationResetData(
+        @SerialName("group_id") val groupId: String,
+        @SerialName("new_group_id") val newGroupId: String
     )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
@@ -243,13 +243,13 @@ internal class EventsRouter internal constructor(
                         timestamp = event.time
                     )
                 } catch (exception: MlsException) {
-                    logger.debug("Message decryption failed, MlsException: ", exception)
+                    logger.warn("Message decryption failed, MlsException: ", exception)
                     mlsFallbackStrategy.verifyConversationOutOfSync(
                         mlsGroupId = mlsGroupId,
                         conversationId = event.qualifiedConversation
                     )
                 } catch (exception: CoreCryptoException.Mls) {
-                    logger.debug(
+                    logger.warn(
                         "Message decryption failed, CoreCryptoException.Mls:",
                         exception
                     )
@@ -262,6 +262,14 @@ internal class EventsRouter internal constructor(
 
             is EventContentDTO.Conversation.MessageTimerUpdateDTO -> {
                 processMessageTimerUpdateDTO(event)
+            }
+
+            is EventContentDTO.Conversation.MlsReset -> {
+                logger.info("MLS reset event received for: ${event.qualifiedConversation}")
+                conversationService.resetMlsConversation(
+                    conversationId = event.qualifiedConversation,
+                    newGroupId = event.data.newGroupId
+                )
             }
 
             is EventContentDTO.Conversation.Typing -> {

--- a/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
@@ -484,6 +484,36 @@ internal class ConversationService internal constructor(
         }
     }
 
+    /**
+     * Resets the MLS group of a conversation. Called when receiving a conversation.mls-reset event.
+     * If the conversation already has the new MLS groupId, no-op (idempotent for duplicate events).
+     * Otherwise wipes the old MLS group from CoreCrypto and deletes the conversation (and its
+     * members) from local storage. It will be re-established on the next interaction.
+     */
+    suspend fun resetMlsConversation(
+        conversationId: QualifiedId,
+        newGroupId: String
+    ) {
+        val newMlsGroupId = ConversationId(newGroupId.decodeBase64Bytes())
+        val conversation = conversationStorage.getById(conversationId)
+        if (conversation == null) {
+            logger.warn(
+                "Conversation {} not found in storage during MLS reset. Already deleted?",
+                conversationId
+            )
+            return
+        }
+        if (conversation.mlsGroupId == newMlsGroupId) {
+            logger.info(
+                "Conversation {} already has the new MLS Group ID, skipping reset.",
+                conversationId
+            )
+            return
+        }
+        deleteAllConversationDataFromLocalStorages(conversationId, conversation.mlsGroupId)
+        logger.info("MLS conversation reset. conversationId: {}", conversationId)
+    }
+
     suspend fun leaveConversation(conversationId: QualifiedId) {
         logger.info("Attempting to leave conversation. conversationId: {}", conversationId)
 

--- a/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
@@ -30,6 +30,7 @@ import com.wire.sdk.model.http.conversation.MemberJoinEventData
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -380,6 +381,52 @@ class EventsRouterConcurrencyTest {
             assertEquals(2, processedTeamInvites.size)
             assertTrue(processedTeamInvites.contains(teamId1))
             assertTrue(processedTeamInvites.contains(teamId2))
+
+            eventsRouter.close()
+        }
+
+    @Test
+    fun `mls reset event delegates to conversationService with new groupId`() =
+        runTest {
+            val conversationId = QualifiedId(id = UUID.randomUUID(), domain = "wire.test")
+            val newGroupId = "newGroupIdBase64=="
+            val conversationService = mockk<ConversationService>()
+
+            coEvery {
+                conversationService.resetMlsConversation(any(), any())
+            } returns Unit
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val eventsRouter = createEventsRouter(
+                conversationService = conversationService,
+                dispatcher = testDispatcher
+            )
+
+            val event = EventContentDTO.Conversation.MlsReset(
+                qualifiedConversation = conversationId,
+                qualifiedFrom = QualifiedId(UUID.randomUUID(), "wire.test"),
+                time = Clock.System.now(),
+                data = EventContentDTO.MlsConversationResetData(
+                    groupId = "oldGroupIdBase64==",
+                    newGroupId = newGroupId
+                )
+            )
+
+            eventsRouter.route(
+                EventResponse(
+                    id = UUID.randomUUID().toString(),
+                    payload = listOf(event)
+                )
+            )
+
+            testScheduler.advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                conversationService.resetMlsConversation(
+                    conversationId = conversationId,
+                    newGroupId = newGroupId
+                )
+            }
 
             eventsRouter.close()
         }

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireEventsTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireEventsTest.kt
@@ -100,6 +100,19 @@ class WireEventsTest {
     }
 
     @Test
+    fun whenDeserializingMlsResetEventThenItShouldMapCorrectlyToMlsReset() {
+        val event =
+            KtxSerializer.json.decodeFromString<EventResponse>(
+                DUMMY_MLS_RESET_EVENT_RESPONSE
+            )
+
+        val payload = event.payload?.first()
+        assertIs<EventContentDTO.Conversation.MlsReset>(payload)
+        assertEquals("oldGroupIdBase64==", payload.data.groupId)
+        assertEquals("newGroupIdBase64==", payload.data.newGroupId)
+    }
+
+    @Test
     fun givenWireEventsHandlerIsInjectedThenCallingNewPingMethodItSucceeds() =
         runBlocking {
             val wireEvents = IsolatedKoinContext
@@ -145,6 +158,30 @@ class WireEventsTest {
 
         private const val EXPECTED_LOCATION_LATITUDE = 11.12345F
         private const val EXPECTED_LOCATION_LONGITUDE = 12.12345F
+
+        private val DUMMY_MLS_RESET_EVENT_RESPONSE =
+            """{
+                  "id": "4c2c48f6-84af-11ef-8001-860acb7b851a",
+                  "payload": [
+                    {
+                      "qualified_conversation": {
+                        "domain": "${CONVERSATION_ID.domain}",
+                        "id": "${CONVERSATION_ID.id}"
+                      },
+                      "qualified_from": {
+                        "domain": "anta.wire.link",
+                        "id": "95d52e20-8428-4619-9a81-dbc2298a3f28"
+                      },
+                      "time": "2024-10-07T13:23:10.386Z",
+                      "data": {
+                        "group_id": "oldGroupIdBase64==",
+                        "new_group_id": "newGroupIdBase64=="
+                      },
+                      "type": "conversation.mls-reset"
+                    }
+                  ]
+                }
+            """
 
         private val DUMMY_CONVERSATION_CREATE_EVENT_RESPONSE =
             """{

--- a/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
@@ -1759,6 +1759,99 @@ class ConversationServiceTest {
         coVerify(exactly = 0) { usersApiClient.getUserData(any()) }
     }
 
+    @Test
+    fun whenResettingMlsConversationThenWipeOldGroupAndDeleteFromLocalStorage() =
+        runTest {
+            val newMlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+            val newMlsGroupIdBase64 =
+                Base64.getEncoder().encodeToString(newMlsGroupId.copyBytes())
+            val existingConversation = ConversationEntity(
+                id = CONVERSATION_ID,
+                name = "Test-Group-Conversation",
+                mlsGroupId = CONVERSATION_MLS_GROUP_ID,
+                teamId = TEAM_ID,
+                type = ConversationEntity.Type.GROUP
+            )
+
+            val conversationStorage = mockk<ConversationStorage> {
+                every { getById(CONVERSATION_ID) } returns existingConversation
+                every { delete(CONVERSATION_ID) } returns Unit
+                every { deleteAllMembersInConversation(CONVERSATION_ID) } returns Unit
+            }
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(CONVERSATION_MLS_GROUP_ID) } returns true
+                coEvery { wipeConversation(CONVERSATION_MLS_GROUP_ID) } returns Unit
+            }
+
+            val service = ConversationService(
+                backendClient = mockk(),
+                usersApiClient = mockk(),
+                selfApiClient = mockk(),
+                conversationsApiClient = mockk(),
+                oneToOneConversationsApiClient = mockk(),
+                teamsApiClient = mockk(),
+                mlsApiClient = mockk(),
+                conversationStorage = conversationStorage,
+                appStorage = mockk(),
+                cryptoClient = cryptoClient
+            )
+
+            service.resetMlsConversation(
+                conversationId = CONVERSATION_ID,
+                newGroupId = newMlsGroupIdBase64
+            )
+
+            coVerify(exactly = 1) {
+                cryptoClient.wipeConversation(CONVERSATION_MLS_GROUP_ID)
+            }
+            verify(exactly = 1) { conversationStorage.delete(any()) }
+        }
+
+    @Test
+    fun whenResettingMlsConversationAndCryptoGroupDoesNotExistThenSkipWipeAndStillDelete() =
+        runTest {
+            val newMlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+            val newMlsGroupIdBase64 =
+                Base64.getEncoder().encodeToString(newMlsGroupId.copyBytes())
+            val existingConversation = ConversationEntity(
+                id = CONVERSATION_ID,
+                name = "Test-Group-Conversation",
+                mlsGroupId = CONVERSATION_MLS_GROUP_ID,
+                teamId = TEAM_ID,
+                type = ConversationEntity.Type.GROUP
+            )
+
+            val conversationStorage = mockk<ConversationStorage> {
+                every { getById(CONVERSATION_ID) } returns existingConversation
+                every { delete(CONVERSATION_ID) } returns Unit
+                every { deleteAllMembersInConversation(CONVERSATION_ID) } returns Unit
+            }
+            val cryptoClient = mockk<CryptoClient> {
+                coEvery { conversationExists(CONVERSATION_MLS_GROUP_ID) } returns false
+            }
+
+            val service = ConversationService(
+                backendClient = mockk(),
+                usersApiClient = mockk(),
+                selfApiClient = mockk(),
+                conversationsApiClient = mockk(),
+                oneToOneConversationsApiClient = mockk(),
+                teamsApiClient = mockk(),
+                mlsApiClient = mockk(),
+                conversationStorage = conversationStorage,
+                appStorage = mockk(),
+                cryptoClient = cryptoClient
+            )
+
+            service.resetMlsConversation(
+                conversationId = CONVERSATION_ID,
+                newGroupId = newMlsGroupIdBase64
+            )
+
+            coVerify(exactly = 0) { cryptoClient.wipeConversation(any()) }
+            verify(exactly = 1) { conversationStorage.delete(any()) }
+        }
+
     private companion object {
         const val BACKEND_DOMAIN = "wire.com"
         val CONVERSATION_ID =


### PR DESCRIPTION
Adds support for the conversation.mls-reset backend event, sent when another client resets a broken MLS conversation. On receipt the SDK wipes the old MLS group from CoreCrypto and deletes the local conversation (and its members) from storage so it can be re-established on the next interaction. The handler is idempotent: if the locally stored mlsGroupId already matches the new one, the reset is skipped.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MLS reset event was not handled

### Causes (Optional)

Potentially broken conversations when reset happened

### Solutions

Handle the event, simply remove the conversation and wait for next mls-welcome

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
