### PR TITLE
chore: WPB-25522 Introduce WireUser class and adapt getUser and searchUser methods

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -135,11 +135,11 @@ val sdkModule =
                 get()
             )
         }
-        single { UserService(get()) }
+        single { UserService(get(), get()) }
 
         // Manager
         single {
-            WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get(), get())
+            WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get())
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -50,6 +50,7 @@ import com.wire.sdk.persistence.TeamSqlLiteStorage
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.EventsRouter
 import com.wire.sdk.service.MlsFallbackStrategy
+import com.wire.sdk.service.UserService
 import com.wire.sdk.service.WireApplicationManager
 import com.wire.sdk.service.WireTeamEventsListener
 import com.wire.sdk.service.conversation.ConversationService
@@ -134,6 +135,7 @@ val sdkModule =
                 get()
             )
         }
+        single { UserService(get()) }
 
         // Manager
         single {

--- a/lib/src/main/kotlin/com/wire/sdk/model/WireUser.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/WireUser.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model
+
+import java.util.UUID
+
+/**
+ * Represents a Wire user exposed through the public SDK API.
+ *
+ * @property id The qualified user identity (UUID + domain).
+ * @property name The display name of the user.
+ * @property email The email address of the user.
+ * @property handle The unique handle (username) of the user.
+ * @property teamId The UUID of the team the user belongs to.
+ * @property supportedProtocols The list of cryptographic protocols supported by the user.
+ * @property deleted Whether the user account has been deleted.
+ */
+@JvmRecord
+data class WireUser(
+    val id: QualifiedId,
+    val name: String,
+    val email: String?,
+    val handle: String?,
+    val teamId: UUID?,
+    val supportedProtocols: List<CryptoProtocol>,
+    val deleted: Boolean?
+)

--- a/lib/src/main/kotlin/com/wire/sdk/model/WireUser.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/WireUser.kt
@@ -26,7 +26,6 @@ import java.util.UUID
  * @property email The email address of the user.
  * @property handle The unique handle (username) of the user.
  * @property teamId The UUID of the team the user belongs to.
- * @property supportedProtocols The list of cryptographic protocols supported by the user.
  * @property deleted Whether the user account has been deleted.
  */
 @JvmRecord
@@ -36,6 +35,5 @@ data class WireUser(
     val email: String?,
     val handle: String?,
     val teamId: UUID?,
-    val supportedProtocols: List<CryptoProtocol>,
     val deleted: Boolean?
 )

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/search/SearchContactsResponse.kt
@@ -38,18 +38,18 @@ data class SearchContactsResponse(
 
 @Serializable
 data class ContactDocument(
-    @SerialName("accent_id")
-    val accentId: Long?,
-    @SerialName("handle")
-    val handle: String?,
+    @SerialName("qualified_id")
+    val qualifiedId: QualifiedId,
     @SerialName("id")
     val id: String,
+    @SerialName("handle")
+    val handle: String?,
     @SerialName("name")
     val name: String,
-    @SerialName("qualified_id")
-    val qualifiedId: QualifiedId?,
-    @SerialName("team")
-    val team: String?,
+    @SerialName("accent_id")
+    val accentId: Long?,
     @SerialName("type")
-    val type: String?
+    val type: String,
+    @SerialName("team")
+    val team: String?
 )

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -89,6 +89,7 @@ internal class UserService(
 
     private fun ContactDocument.toWireUser(): WireUser = WireUser(
         id = qualifiedId ?: QualifiedId(id = UUID.fromString(id), domain = ""),
+        // TODO: Baris is currently clarifying if qualifiedId can be null. Asked to backend
         name = name,
         email = null,
         handle = handle,

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -89,8 +89,7 @@ internal class UserService(
 
     private fun ContactDocument.toWireUser(): WireUser =
         WireUser(
-            id = qualifiedId ?: QualifiedId(id = UUID.fromString(id), domain = ""),
-            // TODO: Baris is currently clarifying if qualifiedId can be null. Asked to backend
+            id = qualifiedId,
             name = name,
             email = null,
             handle = handle,

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -16,17 +16,23 @@
 
 package com.wire.sdk.service
 
+import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.WireUser
+import com.wire.sdk.model.http.search.ContactDocument
 import com.wire.sdk.model.http.user.UserResponse
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * Service layer responsible for fetching user data from the backend and mapping
  * internal HTTP response models to public SDK [WireUser] objects.
  */
-internal class UserService(private val usersApiClient: UsersApiClient) {
+internal class UserService(
+    private val usersApiClient: UsersApiClient,
+    private val searchApiClient: SearchApiClient
+) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -45,6 +51,32 @@ internal class UserService(private val usersApiClient: UsersApiClient) {
         return usersApiClient.getUserData(userId).toWireUser()
     }
 
+    /**
+     * Searches for users matching the given [query] on the specified [domain] and returns
+     * a list of [WireUser] objects.
+     *
+     * Fields not present in the search response ([WireUser.email], [WireUser.supportedProtocols],
+     * [WireUser.deleted]) are set to `null` or an empty list respectively.
+     *
+     * @param query The search string to match against user names and handles.
+     * @param domain The domain to restrict the search to.
+     * @param numberOfResults The maximum number of results to return,
+     * or null to use the backend default.
+     * @return A list of [WireUser] objects matching the query.
+     */
+    suspend fun searchUsers(
+        query: String,
+        domain: String,
+        numberOfResults: Int? = null
+    ): List<WireUser> {
+        logger.info("Searching users with query: $query on domain: $domain")
+        return searchApiClient.searchUsers(
+            query = query,
+            domain = domain,
+            numberOfResults = numberOfResults
+        ).documents.map { it.toWireUser() }
+    }
+
     private fun UserResponse.toWireUser(): WireUser = WireUser(
         id = id,
         name = name,
@@ -54,6 +86,14 @@ internal class UserService(private val usersApiClient: UsersApiClient) {
         supportedProtocols = supportedProtocols,
         deleted = deleted
     )
+
+    private fun ContactDocument.toWireUser(): WireUser = WireUser(
+        id = qualifiedId ?: QualifiedId(id = UUID.fromString(id), domain = ""),
+        name = name,
+        email = null,
+        handle = handle,
+        teamId = team?.let { runCatching { UUID.fromString(it) }.getOrNull() },
+        supportedProtocols = emptyList(),
+        deleted = null
+    )
 }
-
-

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -33,7 +33,6 @@ internal class UserService(
     private val usersApiClient: UsersApiClient,
     private val searchApiClient: SearchApiClient
 ) {
-
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     /**
@@ -77,24 +76,26 @@ internal class UserService(
         ).documents.map { it.toWireUser() }
     }
 
-    private fun UserResponse.toWireUser(): WireUser = WireUser(
-        id = id,
-        name = name,
-        email = email,
-        handle = handle,
-        teamId = teamId,
-        supportedProtocols = supportedProtocols,
-        deleted = deleted
-    )
+    private fun UserResponse.toWireUser(): WireUser =
+        WireUser(
+            id = id,
+            name = name,
+            email = email,
+            handle = handle,
+            teamId = teamId,
+            supportedProtocols = supportedProtocols,
+            deleted = deleted
+        )
 
-    private fun ContactDocument.toWireUser(): WireUser = WireUser(
-        id = qualifiedId ?: QualifiedId(id = UUID.fromString(id), domain = ""),
-        // TODO: Baris is currently clarifying if qualifiedId can be null. Asked to backend
-        name = name,
-        email = null,
-        handle = handle,
-        teamId = team?.let { runCatching { UUID.fromString(it) }.getOrNull() },
-        supportedProtocols = emptyList(),
-        deleted = null
-    )
+    private fun ContactDocument.toWireUser(): WireUser =
+        WireUser(
+            id = qualifiedId ?: QualifiedId(id = UUID.fromString(id), domain = ""),
+            // TODO: Baris is currently clarifying if qualifiedId can be null. Asked to backend
+            name = name,
+            email = null,
+            handle = handle,
+            teamId = team?.let { runCatching { UUID.fromString(it) }.getOrNull() },
+            supportedProtocols = emptyList(),
+            deleted = null
+        )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -54,8 +54,8 @@ internal class UserService(
      * Searches for users matching the given [query] on the specified [domain] and returns
      * a list of [WireUser] objects.
      *
-     * Fields not present in the search response ([WireUser.email], [WireUser.supportedProtocols],
-     * [WireUser.deleted]) are set to `null` or an empty list respectively.
+     * Fields not present in the search response ([WireUser.email],
+     * [WireUser.deleted]) are set to `null`.
      *
      * @param query The search string to match against user names and handles.
      * @param domain The domain to restrict the search to.
@@ -83,7 +83,6 @@ internal class UserService(
             email = email,
             handle = handle,
             teamId = teamId,
-            supportedProtocols = supportedProtocols,
             deleted = deleted
         )
 
@@ -94,7 +93,6 @@ internal class UserService(
             email = null,
             handle = handle,
             teamId = team?.let { runCatching { UUID.fromString(it) }.getOrNull() },
-            supportedProtocols = emptyList(),
             deleted = null
         )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/UserService.kt
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.service
+
+import com.wire.sdk.client.UsersApiClient
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.WireUser
+import com.wire.sdk.model.http.user.UserResponse
+import org.slf4j.LoggerFactory
+
+/**
+ * Service layer responsible for fetching user data from the backend and mapping
+ * internal HTTP response models to public SDK [WireUser] objects.
+ */
+internal class UserService(private val usersApiClient: UsersApiClient) {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    /**
+     * Fetches the user data for the given [userId] and returns a [WireUser].
+     *
+     * Nullable fields in the backend response ([UserResponse.email], [UserResponse.handle],
+     * [UserResponse.teamId], [UserResponse.deleted]) are preserved as `null` in the
+     * returned [WireUser].
+     *
+     * @param userId The qualified ID of the user to fetch.
+     * @return A [WireUser] populated with the response data.
+     */
+    suspend fun getUser(userId: QualifiedId): WireUser {
+        logger.info("Fetching user: $userId")
+        return usersApiClient.getUserData(userId).toWireUser()
+    }
+
+    private fun UserResponse.toWireUser(): WireUser = WireUser(
+        id = id,
+        name = name,
+        email = email,
+        handle = handle,
+        teamId = teamId,
+        supportedProtocols = supportedProtocols,
+        deleted = deleted
+    )
+}
+
+

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -409,8 +409,7 @@ class WireApplicationManager internal constructor(
      * Suspending method for Kotlin consumers
      */
     @Throws(WireException::class)
-    suspend fun getUserSuspending(userId: QualifiedId): WireUser =
-        userService.getUser(userId)
+    suspend fun getUserSuspending(userId: QualifiedId): WireUser = userService.getUser(userId)
 
     /**
      * Creates a Group Conversation where currently the only admin is the App
@@ -689,9 +688,10 @@ class WireApplicationManager internal constructor(
         query: String,
         domain: String,
         numberOfResults: Int? = null
-    ): List<WireUser> = userService.searchUsers(
-        query = query,
-        domain = domain,
-        numberOfResults = numberOfResults
-    )
+    ): List<WireUser> =
+        userService.searchUsers(
+            query = query,
+            domain = domain,
+            numberOfResults = numberOfResults
+        )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -18,7 +18,6 @@ package com.wire.sdk.service
 import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
-import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.AssetResource
@@ -35,7 +34,6 @@ import com.wire.sdk.model.asset.AssetUploadData
 import com.wire.sdk.model.conversation.AddMembersToConversationResult
 import com.wire.sdk.model.http.ApiVersionResponse
 import com.wire.sdk.model.http.conversation.ConversationRole
-import com.wire.sdk.model.http.search.SearchContactsResponse
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
@@ -62,7 +60,6 @@ class WireApplicationManager internal constructor(
     private val userService: UserService,
     private val mlsApiClient: MlsApiClient,
     private val assetsApiClient: AssetsApiClient,
-    private val searchApiClient: SearchApiClient,
     private val cryptoClient: CryptoClient,
     private val mlsFallbackStrategy: MlsFallbackStrategy,
     private val conversationService: ConversationService
@@ -667,7 +664,7 @@ class WireApplicationManager internal constructor(
      * @param domain The domain to restrict the search to.
      * @param numberOfResults The maximum number of results to return,
      * or null to use the SDK default (15).
-     * @return A [SearchContactsResponse] containing the list of matched users.
+     * @return A list of [WireUser] objects matching the query.
      * @throws WireException If the request fails or an error occurs while searching.
      */
     @JvmOverloads
@@ -675,7 +672,7 @@ class WireApplicationManager internal constructor(
         query: String,
         domain: String,
         numberOfResults: Int? = null
-    ): SearchContactsResponse {
+    ): List<WireUser> {
         return runBlocking {
             searchUsersSuspending(
                 query = query,
@@ -692,11 +689,9 @@ class WireApplicationManager internal constructor(
         query: String,
         domain: String,
         numberOfResults: Int? = null
-    ): SearchContactsResponse {
-        return searchApiClient.searchUsers(
-            query = query,
-            domain = domain,
-            numberOfResults = numberOfResults
-        )
-    }
+    ): List<WireUser> = userService.searchUsers(
+        query = query,
+        domain = domain,
+        numberOfResults = numberOfResults
+    )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -19,7 +19,6 @@ import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.client.SearchApiClient
-import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.AssetResource
@@ -30,13 +29,13 @@ import com.wire.sdk.model.EncryptionKey
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.WireMessage
+import com.wire.sdk.model.WireUser
 import com.wire.sdk.model.asset.AssetRetention
 import com.wire.sdk.model.asset.AssetUploadData
 import com.wire.sdk.model.conversation.AddMembersToConversationResult
 import com.wire.sdk.model.http.ApiVersionResponse
 import com.wire.sdk.model.http.conversation.ConversationRole
 import com.wire.sdk.model.http.search.SearchContactsResponse
-import com.wire.sdk.model.http.user.UserResponse
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
@@ -60,7 +59,7 @@ import org.slf4j.LoggerFactory
 class WireApplicationManager internal constructor(
     private val teamStorage: TeamStorage,
     private val backendClient: BackendClient,
-    private val usersApiClient: UsersApiClient,
+    private val userService: UserService,
     private val mlsApiClient: MlsApiClient,
     private val assetsApiClient: AssetsApiClient,
     private val searchApiClient: SearchApiClient,
@@ -403,7 +402,7 @@ class WireApplicationManager internal constructor(
      * Blocking method for Java interoperability
      */
     @Throws(WireException::class)
-    fun getUser(userId: QualifiedId): UserResponse =
+    fun getUser(userId: QualifiedId): WireUser =
         runBlocking {
             getUserSuspending(userId)
         }
@@ -413,8 +412,8 @@ class WireApplicationManager internal constructor(
      * Suspending method for Kotlin consumers
      */
     @Throws(WireException::class)
-    suspend fun getUserSuspending(userId: QualifiedId): UserResponse =
-        usersApiClient.getUserData(userId)
+    suspend fun getUserSuspending(userId: QualifiedId): WireUser =
+        userService.getUser(userId)
 
     /**
      * Creates a Group Conversation where currently the only admin is the App

--- a/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/SearchApiClientTest.kt
@@ -183,8 +183,8 @@ class SearchApiClientTest {
             val result = apiClient(
                 SEARCH_RESPONSE_WITH_RESULTS
             ).searchUsers(query = "Alice", domain = "wire.com")
-            assertEquals("wire.com", result.documents.first().qualifiedId?.domain)
-            assertEquals(UUID.fromString(USER_ID), result.documents.first().qualifiedId?.id)
+            assertEquals("wire.com", result.documents.first().qualifiedId.domain)
+            assertEquals(UUID.fromString(USER_ID), result.documents.first().qualifiedId.id)
         }
 
     @Test

--- a/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class WireUserTest {
-
     private val userId = UUID.fromString("00000000-0000-0000-0000-000000000001")
     private val teamId = UUID.fromString("00000000-0000-0000-0000-000000000002")
     private val domain = "example.com"

--- a/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
@@ -19,7 +19,6 @@ package com.wire.sdk.model
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -34,10 +33,6 @@ class WireUserTest {
         email: String? = "alice@example.com",
         handle: String? = "alice",
         teamId: UUID? = this.teamId,
-        supportedProtocols: List<CryptoProtocol> = listOf(
-            CryptoProtocol.PROTEUS,
-            CryptoProtocol.MLS
-        ),
         deleted: Boolean? = false
     ) = WireUser(
         id = id,
@@ -45,7 +40,6 @@ class WireUserTest {
         email = email,
         handle = handle,
         teamId = teamId,
-        supportedProtocols = supportedProtocols,
         deleted = deleted
     )
 
@@ -61,7 +55,6 @@ class WireUserTest {
         assertEquals("alice@example.com", user.email)
         assertEquals("alice", user.handle)
         assertEquals(teamId, user.teamId)
-        assertEquals(listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS), user.supportedProtocols)
         assertEquals(false, user.deleted)
     }
 
@@ -98,29 +91,6 @@ class WireUserTest {
         val user = buildUser(deleted = true)
 
         assertEquals(true, user.deleted)
-    }
-
-    @Test
-    fun `should allow empty supportedProtocols list`() {
-        val user = buildUser(supportedProtocols = emptyList())
-
-        assertTrue(user.supportedProtocols.isEmpty())
-    }
-
-    @Test
-    fun `should allow single protocol in supportedProtocols`() {
-        val user = buildUser(supportedProtocols = listOf(CryptoProtocol.MLS))
-
-        assertEquals(1, user.supportedProtocols.size)
-        assertEquals(CryptoProtocol.MLS, user.supportedProtocols[0])
-    }
-
-    @Test
-    fun `should allow all CryptoProtocol values in supportedProtocols`() {
-        val allProtocols = listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS, CryptoProtocol.MIXED)
-        val user = buildUser(supportedProtocols = allProtocols)
-
-        assertEquals(allProtocols, user.supportedProtocols)
     }
 
     // --- Equality ---
@@ -193,14 +163,6 @@ class WireUserTest {
     fun `two users with null and non-null teamId should not be equal`() {
         val userA = buildUser(teamId = UUID.randomUUID())
         val userB = buildUser(teamId = null)
-
-        assertNotEquals(userA, userB)
-    }
-
-    @Test
-    fun `two users with different supportedProtocols should not be equal`() {
-        val userA = buildUser(supportedProtocols = listOf(CryptoProtocol.PROTEUS))
-        val userB = buildUser(supportedProtocols = listOf(CryptoProtocol.MLS))
 
         assertNotEquals(userA, userB)
     }

--- a/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
@@ -35,7 +35,10 @@ class WireUserTest {
         email: String? = "alice@example.com",
         handle: String? = "alice",
         teamId: UUID? = this.teamId,
-        supportedProtocols: List<CryptoProtocol> = listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS),
+        supportedProtocols: List<CryptoProtocol> = listOf(
+            CryptoProtocol.PROTEUS,
+            CryptoProtocol.MLS
+        ),
         deleted: Boolean? = false
     ) = WireUser(
         id = id,

--- a/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/WireUserTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class WireUserTest {
+
+    private val userId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    private val teamId = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    private val domain = "example.com"
+
+    private fun buildUser(
+        id: QualifiedId = QualifiedId(userId, domain),
+        name: String = "Alice",
+        email: String? = "alice@example.com",
+        handle: String? = "alice",
+        teamId: UUID? = this.teamId,
+        supportedProtocols: List<CryptoProtocol> = listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS),
+        deleted: Boolean? = false
+    ) = WireUser(
+        id = id,
+        name = name,
+        email = email,
+        handle = handle,
+        teamId = teamId,
+        supportedProtocols = supportedProtocols,
+        deleted = deleted
+    )
+
+    // --- Construction ---
+
+    @Test
+    fun `should store all fields correctly`() {
+        val qualifiedId = QualifiedId(userId, domain)
+        val user = buildUser(id = qualifiedId)
+
+        assertEquals(qualifiedId, user.id)
+        assertEquals("Alice", user.name)
+        assertEquals("alice@example.com", user.email)
+        assertEquals("alice", user.handle)
+        assertEquals(teamId, user.teamId)
+        assertEquals(listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS), user.supportedProtocols)
+        assertEquals(false, user.deleted)
+    }
+
+    @Test
+    fun `should allow null email`() {
+        val user = buildUser(email = null)
+
+        assertNull(user.email)
+    }
+
+    @Test
+    fun `should allow null handle`() {
+        val user = buildUser(handle = null)
+
+        assertNull(user.handle)
+    }
+
+    @Test
+    fun `should allow null teamId`() {
+        val user = buildUser(teamId = null)
+
+        assertNull(user.teamId)
+    }
+
+    @Test
+    fun `should allow null deleted`() {
+        val user = buildUser(deleted = null)
+
+        assertNull(user.deleted)
+    }
+
+    @Test
+    fun `should allow deleted to be true`() {
+        val user = buildUser(deleted = true)
+
+        assertEquals(true, user.deleted)
+    }
+
+    @Test
+    fun `should allow empty supportedProtocols list`() {
+        val user = buildUser(supportedProtocols = emptyList())
+
+        assertTrue(user.supportedProtocols.isEmpty())
+    }
+
+    @Test
+    fun `should allow single protocol in supportedProtocols`() {
+        val user = buildUser(supportedProtocols = listOf(CryptoProtocol.MLS))
+
+        assertEquals(1, user.supportedProtocols.size)
+        assertEquals(CryptoProtocol.MLS, user.supportedProtocols[0])
+    }
+
+    @Test
+    fun `should allow all CryptoProtocol values in supportedProtocols`() {
+        val allProtocols = listOf(CryptoProtocol.PROTEUS, CryptoProtocol.MLS, CryptoProtocol.MIXED)
+        val user = buildUser(supportedProtocols = allProtocols)
+
+        assertEquals(allProtocols, user.supportedProtocols)
+    }
+
+    // --- Equality ---
+
+    @Test
+    fun `two users with same fields should be equal`() {
+        val userA = buildUser()
+        val userB = buildUser()
+
+        assertEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with same fields should have same hashCode`() {
+        val userA = buildUser()
+        val userB = buildUser()
+
+        assertEquals(userA.hashCode(), userB.hashCode())
+    }
+
+    @Test
+    fun `two users with different ids should not be equal`() {
+        val userA = buildUser(id = QualifiedId(userId, domain))
+        val userB = buildUser(id = QualifiedId(UUID.randomUUID(), domain))
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different names should not be equal`() {
+        val userA = buildUser(name = "Alice")
+        val userB = buildUser(name = "Bob")
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different emails should not be equal`() {
+        val userA = buildUser(email = "alice@example.com")
+        val userB = buildUser(email = "bob@example.com")
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with null and non-null email should not be equal`() {
+        val userA = buildUser(email = "alice@example.com")
+        val userB = buildUser(email = null)
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different handles should not be equal`() {
+        val userA = buildUser(handle = "alice")
+        val userB = buildUser(handle = "bob")
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different teamIds should not be equal`() {
+        val userA = buildUser(teamId = UUID.randomUUID())
+        val userB = buildUser(teamId = UUID.randomUUID())
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with null and non-null teamId should not be equal`() {
+        val userA = buildUser(teamId = UUID.randomUUID())
+        val userB = buildUser(teamId = null)
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different supportedProtocols should not be equal`() {
+        val userA = buildUser(supportedProtocols = listOf(CryptoProtocol.PROTEUS))
+        val userB = buildUser(supportedProtocols = listOf(CryptoProtocol.MLS))
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with different deleted flags should not be equal`() {
+        val userA = buildUser(deleted = false)
+        val userB = buildUser(deleted = true)
+
+        assertNotEquals(userA, userB)
+    }
+
+    @Test
+    fun `two users with null and non-null deleted should not be equal`() {
+        val userA = buildUser(deleted = false)
+        val userB = buildUser(deleted = null)
+
+        assertNotEquals(userA, userB)
+    }
+
+    // --- Copy ---
+
+    @Test
+    fun `copy should produce equal object when no fields changed`() {
+        val user = buildUser()
+        val copy = user.copy()
+
+        assertEquals(user, copy)
+    }
+
+    @Test
+    fun `copy with changed name should differ from original`() {
+        val user = buildUser(name = "Alice")
+        val updated = user.copy(name = "Bob")
+
+        assertNotEquals(user, updated)
+        assertEquals("Bob", updated.name)
+        assertEquals(user.id, updated.id)
+    }
+
+    @Test
+    fun `copy with deleted true should reflect updated flag`() {
+        val user = buildUser(deleted = false)
+        val deletedUser = user.copy(deleted = true)
+
+        assertEquals(false, user.deleted)
+        assertEquals(true, deletedUser.deleted)
+    }
+
+    @Test
+    fun `copy with null email should reflect null`() {
+        val user = buildUser(email = "alice@example.com")
+        val updated = user.copy(email = null)
+
+        assertNull(updated.email)
+        assertEquals("alice@example.com", user.email)
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -16,10 +16,13 @@
 
 package com.wire.sdk.service
 
+import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.model.CryptoProtocol
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.WireUser
+import com.wire.sdk.model.http.search.ContactDocument
+import com.wire.sdk.model.http.search.SearchContactsResponse
 import com.wire.sdk.model.http.user.UserResponse
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -37,6 +40,8 @@ class UserServiceTest {
     private val teamId = UUID.fromString("00000000-0000-0000-0000-000000000002")
     private val domain = "example.com"
     private val qualifiedId = QualifiedId(userId, domain)
+
+    // --- Helpers ---
 
     private fun buildResponse(
         id: QualifiedId = qualifiedId,
@@ -58,37 +63,55 @@ class UserServiceTest {
         deleted = deleted
     )
 
-    private fun buildService(response: UserResponse): UserService {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns response
-        return UserService(usersApiClient)
-    }
+    private fun buildContactDocument(
+        id: String = userId.toString(),
+        name: String = "Alice",
+        handle: String? = "alice",
+        qualifiedId: QualifiedId? = this.qualifiedId,
+        team: String? = null
+    ) = ContactDocument(
+        accentId = null,
+        handle = handle,
+        id = id,
+        name = name,
+        qualifiedId = qualifiedId,
+        team = team,
+        type = null
+    )
 
-    // --- Delegation to ApiClient ---
+    // =========================================================================
+    // getUser
+    // =========================================================================
 
     @Test
     fun `getUser delegates to UsersApiClient with the given userId`() = runTest {
         val usersApiClient = mockk<UsersApiClient>()
         coEvery { usersApiClient.getUserData(qualifiedId) } returns buildResponse()
-        val service = UserService(usersApiClient)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
 
         service.getUser(qualifiedId)
 
         coVerify(exactly = 1) { usersApiClient.getUserData(qualifiedId) }
     }
 
-    // --- Mapping: non-nullable fields ---
-
     @Test
     fun `getUser maps id correctly`() = runTest {
-        val user = buildService(buildResponse(id = qualifiedId)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(id = qualifiedId)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals(qualifiedId, user.id)
     }
 
     @Test
     fun `getUser maps name correctly`() = runTest {
-        val user = buildService(buildResponse(name = "Bob")).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(name = "Bob")
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals("Bob", user.name)
     }
@@ -96,84 +119,245 @@ class UserServiceTest {
     @Test
     fun `getUser maps supportedProtocols correctly`() = runTest {
         val protocols = listOf(CryptoProtocol.MLS, CryptoProtocol.PROTEUS)
-        val user = buildService(buildResponse(supportedProtocols = protocols)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(supportedProtocols = protocols)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals(protocols, user.supportedProtocols)
     }
 
-    // --- Mapping: present nullable fields ---
-
     @Test
     fun `getUser maps non-null email correctly`() = runTest {
-        val user = buildService(buildResponse(email = "alice@example.com")).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(email = "alice@example.com")
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals("alice@example.com", user.email)
     }
 
     @Test
     fun `getUser maps non-null handle correctly`() = runTest {
-        val user = buildService(buildResponse(handle = "alice")).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = "alice")
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals("alice", user.handle)
     }
 
     @Test
     fun `getUser maps non-null teamId correctly`() = runTest {
-        val user = buildService(buildResponse(teamId = teamId)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = teamId)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals(teamId, user.teamId)
     }
 
     @Test
     fun `getUser maps non-null deleted true correctly`() = runTest {
-        val user = buildService(buildResponse(deleted = true)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = true)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals(true, user.deleted)
     }
 
     @Test
     fun `getUser maps non-null deleted false correctly`() = runTest {
-        val user = buildService(buildResponse(deleted = false)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = false)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertEquals(false, user.deleted)
     }
 
-    // --- Mapping: null fields are passed through as null ---
-
     @Test
     fun `getUser passes null email through as null`() = runTest {
-        val user = buildService(buildResponse(email = null)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(email = null)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertNull(user.email)
     }
 
     @Test
     fun `getUser passes null handle through as null`() = runTest {
-        val user = buildService(buildResponse(handle = null)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = null)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertNull(user.handle)
     }
 
     @Test
     fun `getUser passes null teamId through as null`() = runTest {
-        val user = buildService(buildResponse(teamId = null)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = null)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertNull(user.teamId)
     }
 
     @Test
     fun `getUser passes null deleted through as null`() = runTest {
-        val user = buildService(buildResponse(deleted = null)).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = null)
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertNull(user.deleted)
     }
 
-    // --- Return type ---
-
     @Test
     fun `getUser returns a WireUser instance`() = runTest {
-        val user = buildService(buildResponse()).getUser(qualifiedId)
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns buildResponse()
+        val service = UserService(usersApiClient, mockk(relaxed = true))
+
+        val user = service.getUser(qualifiedId)
 
         assertTrue(user is WireUser)
+    }
+
+    // =========================================================================
+    // searchUsers
+    // =========================================================================
+
+    @Test
+    fun `searchUsers delegates to SearchApiClient with correct parameters`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery {
+            searchApiClient.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = 10
+            )
+        } returns SearchContactsResponse(documents = listOf(buildContactDocument()))
+        val service = UserService(usersApiClient, searchApiClient)
+
+        service.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
+
+        coVerify(exactly = 1) {
+            searchApiClient.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
+        }
+    }
+
+    @Test
+    fun `searchUsers maps qualifiedId to WireUser id`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(documents = listOf(buildContactDocument(qualifiedId = qualifiedId)))
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertEquals(qualifiedId, result.first().id)
+    }
+
+    @Test
+    fun `searchUsers falls back to bare id with empty domain when qualifiedId is null`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(documents = listOf(buildContactDocument(qualifiedId = null)))
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertEquals(userId, result.first().id.id)
+        assertEquals("", result.first().id.domain)
+    }
+
+    @Test
+    fun `searchUsers maps name and handle correctly`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(name = "Bob", handle = "bob"))
+                )
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Bob", domain = domain, numberOfResults = null)
+
+        assertEquals("Bob", result.first().name)
+        assertEquals("bob", result.first().handle)
+    }
+
+    @Test
+    fun `searchUsers parses team as UUID for teamId`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(team = teamId.toString()))
+                )
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertEquals(teamId, result.first().teamId)
+    }
+
+    @Test
+    fun `searchUsers sets teamId to null when team is null`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(documents = listOf(buildContactDocument(team = null)))
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertNull(result.first().teamId)
+    }
+
+    @Test
+    fun `searchUsers sets email deleted and supportedProtocols to null or empty`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(documents = listOf(buildContactDocument()))
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertNull(result.first().email)
+        assertNull(result.first().deleted)
+        assertTrue(result.first().supportedProtocols.isEmpty())
+    }
+
+    @Test
+    fun `searchUsers returns empty list when documents are empty`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+        val searchApiClient = mockk<SearchApiClient>()
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(documents = emptyList())
+        val service = UserService(usersApiClient, searchApiClient)
+
+        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+
+        assertTrue(result.isEmpty())
     }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -35,7 +35,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class UserServiceTest {
-
     private val userId = UUID.fromString("00000000-0000-0000-0000-000000000001")
     private val teamId = UUID.fromString("00000000-0000-0000-0000-000000000002")
     private val domain = "example.com"
@@ -84,281 +83,338 @@ class UserServiceTest {
     // =========================================================================
 
     @Test
-    fun `getUser delegates to UsersApiClient with the given userId`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(qualifiedId) } returns buildResponse()
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser delegates to UsersApiClient with the given userId`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(qualifiedId) } returns buildResponse()
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        service.getUser(qualifiedId)
+            service.getUser(qualifiedId)
 
-        coVerify(exactly = 1) { usersApiClient.getUserData(qualifiedId) }
-    }
-
-    @Test
-    fun `getUser maps id correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(id = qualifiedId)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertEquals(qualifiedId, user.id)
-    }
+            coVerify(exactly = 1) { usersApiClient.getUserData(qualifiedId) }
+        }
 
     @Test
-    fun `getUser maps name correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(name = "Bob")
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps id correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(id = qualifiedId)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertEquals("Bob", user.name)
-    }
-
-    @Test
-    fun `getUser maps supportedProtocols correctly`() = runTest {
-        val protocols = listOf(CryptoProtocol.MLS, CryptoProtocol.PROTEUS)
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(supportedProtocols = protocols)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertEquals(protocols, user.supportedProtocols)
-    }
+            assertEquals(qualifiedId, user.id)
+        }
 
     @Test
-    fun `getUser maps non-null email correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(email = "alice@example.com")
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps name correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(name = "Bob")
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertEquals("alice@example.com", user.email)
-    }
-
-    @Test
-    fun `getUser maps non-null handle correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = "alice")
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertEquals("alice", user.handle)
-    }
+            assertEquals("Bob", user.name)
+        }
 
     @Test
-    fun `getUser maps non-null teamId correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = teamId)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps supportedProtocols correctly`() =
+        runTest {
+            val protocols = listOf(CryptoProtocol.MLS, CryptoProtocol.PROTEUS)
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns
+                buildResponse(supportedProtocols = protocols)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertEquals(teamId, user.teamId)
-    }
-
-    @Test
-    fun `getUser maps non-null deleted true correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = true)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertEquals(true, user.deleted)
-    }
+            assertEquals(protocols, user.supportedProtocols)
+        }
 
     @Test
-    fun `getUser maps non-null deleted false correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = false)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps non-null email correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns
+                buildResponse(email = "alice@example.com")
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertEquals(false, user.deleted)
-    }
-
-    @Test
-    fun `getUser passes null email through as null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(email = null)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertNull(user.email)
-    }
+            assertEquals("alice@example.com", user.email)
+        }
 
     @Test
-    fun `getUser passes null handle through as null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = null)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps non-null handle correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = "alice")
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertNull(user.handle)
-    }
-
-    @Test
-    fun `getUser passes null teamId through as null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = null)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
-
-        val user = service.getUser(qualifiedId)
-
-        assertNull(user.teamId)
-    }
+            assertEquals("alice", user.handle)
+        }
 
     @Test
-    fun `getUser passes null deleted through as null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = null)
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps non-null teamId correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = teamId)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertNull(user.deleted)
-    }
+            assertEquals(teamId, user.teamId)
+        }
 
     @Test
-    fun `getUser returns a WireUser instance`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>()
-        coEvery { usersApiClient.getUserData(any()) } returns buildResponse()
-        val service = UserService(usersApiClient, mockk(relaxed = true))
+    fun `getUser maps non-null deleted true correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = true)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
 
-        val user = service.getUser(qualifiedId)
+            val user = service.getUser(qualifiedId)
 
-        assertTrue(user is WireUser)
-    }
+            assertEquals(true, user.deleted)
+        }
+
+    @Test
+    fun `getUser maps non-null deleted false correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = false)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertEquals(false, user.deleted)
+        }
+
+    @Test
+    fun `getUser passes null email through as null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(email = null)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertNull(user.email)
+        }
+
+    @Test
+    fun `getUser passes null handle through as null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(handle = null)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertNull(user.handle)
+        }
+
+    @Test
+    fun `getUser passes null teamId through as null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(teamId = null)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertNull(user.teamId)
+        }
+
+    @Test
+    fun `getUser passes null deleted through as null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse(deleted = null)
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertNull(user.deleted)
+        }
+
+    @Test
+    fun `getUser returns a WireUser instance`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>()
+            coEvery { usersApiClient.getUserData(any()) } returns buildResponse()
+            val service = UserService(usersApiClient, mockk(relaxed = true))
+
+            val user = service.getUser(qualifiedId)
+
+            assertTrue(user is WireUser)
+        }
 
     // =========================================================================
     // searchUsers
     // =========================================================================
 
     @Test
-    fun `searchUsers delegates to SearchApiClient with correct parameters`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery {
-            searchApiClient.searchUsers(
-                query = "Alice", domain = domain, numberOfResults = 10
-            )
-        } returns SearchContactsResponse(documents = listOf(buildContactDocument()))
-        val service = UserService(usersApiClient, searchApiClient)
+    fun `searchUsers delegates to SearchApiClient with correct parameters`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery {
+                searchApiClient.searchUsers(
+                    query = "Alice",
+                    domain = domain,
+                    numberOfResults = 10
+                )
+            } returns SearchContactsResponse(documents = listOf(buildContactDocument()))
+            val service = UserService(usersApiClient, searchApiClient)
 
-        service.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
+            service.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
 
-        coVerify(exactly = 1) {
-            searchApiClient.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
+            coVerify(exactly = 1) {
+                searchApiClient.searchUsers(query = "Alice", domain = domain, numberOfResults = 10)
+            }
         }
-    }
 
     @Test
-    fun `searchUsers maps qualifiedId to WireUser id`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument(qualifiedId = qualifiedId))
-        )
-        val service = UserService(usersApiClient, searchApiClient)
+    fun `searchUsers maps qualifiedId to WireUser id`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(qualifiedId = qualifiedId))
+                )
+            val service = UserService(usersApiClient, searchApiClient)
 
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
 
-        assertEquals(qualifiedId, result.first().id)
-    }
-
-    @Test
-    fun `searchUsers falls back to bare id with empty domain when qualifiedId is null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument(qualifiedId = null))
-        )
-        val service = UserService(usersApiClient, searchApiClient)
-
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
-
-        assertEquals(userId, result.first().id.id)
-        assertEquals("", result.first().id.domain)
-    }
+            assertEquals(qualifiedId, result.first().id)
+        }
 
     @Test
-    fun `searchUsers maps name and handle correctly`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument(name = "Bob", handle = "bob"))
-        )
-        val service = UserService(usersApiClient, searchApiClient)
+    fun `searchUsers falls back to bare id with empty domain when qualifiedId is null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(qualifiedId = null))
+                )
+            val service = UserService(usersApiClient, searchApiClient)
 
-        val result = service.searchUsers(query = "Bob", domain = domain, numberOfResults = null)
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
 
-        assertEquals("Bob", result.first().name)
-        assertEquals("bob", result.first().handle)
-    }
-
-    @Test
-    fun `searchUsers parses team as UUID for teamId`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument(team = teamId.toString()))
-        )
-        val service = UserService(usersApiClient, searchApiClient)
-
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
-
-        assertEquals(teamId, result.first().teamId)
-    }
+            assertEquals(userId, result.first().id.id)
+            assertEquals("", result.first().id.domain)
+        }
 
     @Test
-    fun `searchUsers sets teamId to null when team is null`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument(team = null))
-        )
-        val service = UserService(usersApiClient, searchApiClient)
+    fun `searchUsers maps name and handle correctly`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(name = "Bob", handle = "bob"))
+                )
+            val service = UserService(usersApiClient, searchApiClient)
 
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+            val result = service.searchUsers(query = "Bob", domain = domain, numberOfResults = null)
 
-        assertNull(result.first().teamId)
-    }
-
-    @Test
-    fun `searchUsers sets email deleted and supportedProtocols to null or empty`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = listOf(buildContactDocument())
-        )
-        val service = UserService(usersApiClient, searchApiClient)
-
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
-
-        assertNull(result.first().email)
-        assertNull(result.first().deleted)
-        assertTrue(result.first().supportedProtocols.isEmpty())
-    }
+            assertEquals("Bob", result.first().name)
+            assertEquals("bob", result.first().handle)
+        }
 
     @Test
-    fun `searchUsers returns empty list when documents are empty`() = runTest {
-        val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-        val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
-            documents = emptyList()
-        )
-        val service = UserService(usersApiClient, searchApiClient)
+    fun `searchUsers parses team as UUID for teamId`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(team = teamId.toString()))
+                )
+            val service = UserService(usersApiClient, searchApiClient)
 
-        val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
 
-        assertTrue(result.isEmpty())
-    }
+            assertEquals(teamId, result.first().teamId)
+        }
+
+    @Test
+    fun `searchUsers sets teamId to null when team is null`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument(team = null))
+                )
+            val service = UserService(usersApiClient, searchApiClient)
+
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
+
+            assertNull(result.first().teamId)
+        }
+
+    @Test
+    fun `searchUsers sets email deleted and supportedProtocols to null or empty`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = listOf(buildContactDocument())
+                )
+            val service = UserService(usersApiClient, searchApiClient)
+
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
+
+            assertNull(result.first().email)
+            assertNull(result.first().deleted)
+            assertTrue(result.first().supportedProtocols.isEmpty())
+        }
+
+    @Test
+    fun `searchUsers returns empty list when documents are empty`() =
+        runTest {
+            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val searchApiClient = mockk<SearchApiClient>()
+            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
+                SearchContactsResponse(
+                    documents = emptyList()
+                )
+            val service = UserService(usersApiClient, searchApiClient)
+
+            val result = service.searchUsers(
+                query = "Alice",
+                domain = domain,
+                numberOfResults = null
+            )
+
+            assertTrue(result.isEmpty())
+        }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.service
+
+import com.wire.sdk.client.UsersApiClient
+import com.wire.sdk.model.CryptoProtocol
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.WireUser
+import com.wire.sdk.model.http.user.UserResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UserServiceTest {
+
+    private val userId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    private val teamId = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    private val domain = "example.com"
+    private val qualifiedId = QualifiedId(userId, domain)
+
+    private fun buildResponse(
+        id: QualifiedId = qualifiedId,
+        name: String = "Alice",
+        email: String? = "alice@example.com",
+        handle: String? = "alice",
+        teamId: UUID? = this.teamId,
+        accentId: Long = 3L,
+        supportedProtocols: List<CryptoProtocol> = listOf(CryptoProtocol.PROTEUS),
+        deleted: Boolean? = false
+    ) = UserResponse(
+        id = id,
+        name = name,
+        email = email,
+        handle = handle,
+        teamId = teamId,
+        accentId = accentId,
+        supportedProtocols = supportedProtocols,
+        deleted = deleted
+    )
+
+    private fun buildService(response: UserResponse): UserService {
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(any()) } returns response
+        return UserService(usersApiClient)
+    }
+
+    // --- Delegation to ApiClient ---
+
+    @Test
+    fun `getUser delegates to UsersApiClient with the given userId`() = runTest {
+        val usersApiClient = mockk<UsersApiClient>()
+        coEvery { usersApiClient.getUserData(qualifiedId) } returns buildResponse()
+        val service = UserService(usersApiClient)
+
+        service.getUser(qualifiedId)
+
+        coVerify(exactly = 1) { usersApiClient.getUserData(qualifiedId) }
+    }
+
+    // --- Mapping: non-nullable fields ---
+
+    @Test
+    fun `getUser maps id correctly`() = runTest {
+        val user = buildService(buildResponse(id = qualifiedId)).getUser(qualifiedId)
+
+        assertEquals(qualifiedId, user.id)
+    }
+
+    @Test
+    fun `getUser maps name correctly`() = runTest {
+        val user = buildService(buildResponse(name = "Bob")).getUser(qualifiedId)
+
+        assertEquals("Bob", user.name)
+    }
+
+    @Test
+    fun `getUser maps supportedProtocols correctly`() = runTest {
+        val protocols = listOf(CryptoProtocol.MLS, CryptoProtocol.PROTEUS)
+        val user = buildService(buildResponse(supportedProtocols = protocols)).getUser(qualifiedId)
+
+        assertEquals(protocols, user.supportedProtocols)
+    }
+
+    // --- Mapping: present nullable fields ---
+
+    @Test
+    fun `getUser maps non-null email correctly`() = runTest {
+        val user = buildService(buildResponse(email = "alice@example.com")).getUser(qualifiedId)
+
+        assertEquals("alice@example.com", user.email)
+    }
+
+    @Test
+    fun `getUser maps non-null handle correctly`() = runTest {
+        val user = buildService(buildResponse(handle = "alice")).getUser(qualifiedId)
+
+        assertEquals("alice", user.handle)
+    }
+
+    @Test
+    fun `getUser maps non-null teamId correctly`() = runTest {
+        val user = buildService(buildResponse(teamId = teamId)).getUser(qualifiedId)
+
+        assertEquals(teamId, user.teamId)
+    }
+
+    @Test
+    fun `getUser maps non-null deleted true correctly`() = runTest {
+        val user = buildService(buildResponse(deleted = true)).getUser(qualifiedId)
+
+        assertEquals(true, user.deleted)
+    }
+
+    @Test
+    fun `getUser maps non-null deleted false correctly`() = runTest {
+        val user = buildService(buildResponse(deleted = false)).getUser(qualifiedId)
+
+        assertEquals(false, user.deleted)
+    }
+
+    // --- Mapping: null fields are passed through as null ---
+
+    @Test
+    fun `getUser passes null email through as null`() = runTest {
+        val user = buildService(buildResponse(email = null)).getUser(qualifiedId)
+
+        assertNull(user.email)
+    }
+
+    @Test
+    fun `getUser passes null handle through as null`() = runTest {
+        val user = buildService(buildResponse(handle = null)).getUser(qualifiedId)
+
+        assertNull(user.handle)
+    }
+
+    @Test
+    fun `getUser passes null teamId through as null`() = runTest {
+        val user = buildService(buildResponse(teamId = null)).getUser(qualifiedId)
+
+        assertNull(user.teamId)
+    }
+
+    @Test
+    fun `getUser passes null deleted through as null`() = runTest {
+        val user = buildService(buildResponse(deleted = null)).getUser(qualifiedId)
+
+        assertNull(user.deleted)
+    }
+
+    // --- Return type ---
+
+    @Test
+    fun `getUser returns a WireUser instance`() = runTest {
+        val user = buildService(buildResponse()).getUser(qualifiedId)
+
+        assertTrue(user is WireUser)
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -248,9 +248,7 @@ class UserServiceTest {
         val searchApiClient = mockk<SearchApiClient>()
         coEvery {
             searchApiClient.searchUsers(
-                query = "Alice",
-                domain = domain,
-                numberOfResults = 10
+                query = "Alice", domain = domain, numberOfResults = 10
             )
         } returns SearchContactsResponse(documents = listOf(buildContactDocument()))
         val service = UserService(usersApiClient, searchApiClient)
@@ -266,8 +264,9 @@ class UserServiceTest {
     fun `searchUsers maps qualifiedId to WireUser id`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(documents = listOf(buildContactDocument(qualifiedId = qualifiedId)))
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument(qualifiedId = qualifiedId))
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
@@ -279,8 +278,9 @@ class UserServiceTest {
     fun `searchUsers falls back to bare id with empty domain when qualifiedId is null`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(documents = listOf(buildContactDocument(qualifiedId = null)))
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument(qualifiedId = null))
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
@@ -293,10 +293,9 @@ class UserServiceTest {
     fun `searchUsers maps name and handle correctly`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(
-                    documents = listOf(buildContactDocument(name = "Bob", handle = "bob"))
-                )
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument(name = "Bob", handle = "bob"))
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Bob", domain = domain, numberOfResults = null)
@@ -309,10 +308,9 @@ class UserServiceTest {
     fun `searchUsers parses team as UUID for teamId`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(
-                    documents = listOf(buildContactDocument(team = teamId.toString()))
-                )
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument(team = teamId.toString()))
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
@@ -324,8 +322,9 @@ class UserServiceTest {
     fun `searchUsers sets teamId to null when team is null`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(documents = listOf(buildContactDocument(team = null)))
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument(team = null))
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
@@ -337,8 +336,9 @@ class UserServiceTest {
     fun `searchUsers sets email deleted and supportedProtocols to null or empty`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(documents = listOf(buildContactDocument()))
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = listOf(buildContactDocument())
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)
@@ -352,8 +352,9 @@ class UserServiceTest {
     fun `searchUsers returns empty list when documents are empty`() = runTest {
         val usersApiClient = mockk<UsersApiClient>(relaxed = true)
         val searchApiClient = mockk<SearchApiClient>()
-        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(documents = emptyList())
+        coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns SearchContactsResponse(
+            documents = emptyList()
+        )
         val service = UserService(usersApiClient, searchApiClient)
 
         val result = service.searchUsers(query = "Alice", domain = domain, numberOfResults = null)

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -66,7 +66,7 @@ class UserServiceTest {
         id: String = userId.toString(),
         name: String = "Alice",
         handle: String? = "alice",
-        qualifiedId: QualifiedId? = this.qualifiedId,
+        qualifiedId: QualifiedId = this.qualifiedId,
         team: String? = null
     ) = ContactDocument(
         accentId = null,
@@ -75,7 +75,7 @@ class UserServiceTest {
         name = name,
         qualifiedId = qualifiedId,
         team = team,
-        type = null
+        type = "regular"
     )
 
     // =========================================================================
@@ -296,27 +296,6 @@ class UserServiceTest {
             )
 
             assertEquals(qualifiedId, result.first().id)
-        }
-
-    @Test
-    fun `searchUsers falls back to bare id with empty domain when qualifiedId is null`() =
-        runTest {
-            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
-            val searchApiClient = mockk<SearchApiClient>()
-            coEvery { searchApiClient.searchUsers(any(), any(), any()) } returns
-                SearchContactsResponse(
-                    documents = listOf(buildContactDocument(qualifiedId = null))
-                )
-            val service = UserService(usersApiClient, searchApiClient)
-
-            val result = service.searchUsers(
-                query = "Alice",
-                domain = domain,
-                numberOfResults = null
-            )
-
-            assertEquals(userId, result.first().id.id)
-            assertEquals("", result.first().id.domain)
         }
 
     @Test

--- a/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/UserServiceTest.kt
@@ -119,20 +119,6 @@ class UserServiceTest {
         }
 
     @Test
-    fun `getUser maps supportedProtocols correctly`() =
-        runTest {
-            val protocols = listOf(CryptoProtocol.MLS, CryptoProtocol.PROTEUS)
-            val usersApiClient = mockk<UsersApiClient>()
-            coEvery { usersApiClient.getUserData(any()) } returns
-                buildResponse(supportedProtocols = protocols)
-            val service = UserService(usersApiClient, mockk(relaxed = true))
-
-            val user = service.getUser(qualifiedId)
-
-            assertEquals(protocols, user.supportedProtocols)
-        }
-
-    @Test
     fun `getUser maps non-null email correctly`() =
         runTest {
             val usersApiClient = mockk<UsersApiClient>()
@@ -374,7 +360,6 @@ class UserServiceTest {
 
             assertNull(result.first().email)
             assertNull(result.first().deleted)
-            assertTrue(result.first().supportedProtocols.isEmpty())
         }
 
     @Test

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -550,7 +550,6 @@ class WireApplicationManagerTest {
                     email = null,
                     handle = SEARCH_USER_HANDLE,
                     teamId = null,
-                    supportedProtocols = emptyList(),
                     deleted = null
                 )
             )

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -26,7 +26,6 @@ import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
-import com.wire.sdk.client.SearchApiClient
 import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.crypto.MlsCryptoClient
@@ -36,8 +35,8 @@ import com.wire.sdk.model.CryptoClientId
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.WireMessage
+import com.wire.sdk.model.WireUser
 import com.wire.sdk.model.http.conversation.ConversationRole
-import com.wire.sdk.model.http.search.SearchContactsResponse
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
@@ -353,7 +352,6 @@ class WireApplicationManagerTest {
 
             val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
-            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(1, 2, 3)
@@ -367,7 +365,6 @@ class WireApplicationManagerTest {
                 userService = userService,
                 mlsApiClient = mlsApiClient,
                 assetsApiClient = assetsApiClient,
-                searchApiClient = searchApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
                 conversationService = conversationService
@@ -432,7 +429,6 @@ class WireApplicationManagerTest {
 
             val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
-            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(2)
@@ -445,7 +441,6 @@ class WireApplicationManagerTest {
                 backendClient = backendClient,
                 userService = userService,
                 assetsApiClient = assetsApiClient,
-                searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
@@ -509,7 +504,6 @@ class WireApplicationManagerTest {
             val backendClient = mockk<BackendClient>(relaxed = true)
             val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
-            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
@@ -520,7 +514,6 @@ class WireApplicationManagerTest {
                 backendClient = backendClient,
                 userService = userService,
                 assetsApiClient = assetsApiClient,
-                searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
@@ -546,38 +539,38 @@ class WireApplicationManagerTest {
         }
 
     @Test
-    fun `when searchUsers, then delegates to searchApiClient with correct parameters`() =
+    fun `when searchUsers, then delegates to userService with correct parameters`() =
         runTest {
             // Arrange
-            val conversationService = mockk<ConversationService>(relaxed = true)
-            val backendClient = mockk<BackendClient>(relaxed = true)
-            val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
             val userService = mockk<UserService>(relaxed = true)
-            val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
-            val searchApiClient = mockk<SearchApiClient>(relaxed = true)
-            val cryptoClient = mockk<CryptoClient>(relaxed = true)
-            val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
-            val teamStorage = mockk<TeamStorage>(relaxed = true)
-
-            val expectedResponse = SEARCH_CONTACTS_RESPONSE
+            val expectedUsers = listOf(
+                WireUser(
+                    id = SEARCH_USER_QUALIFIED_ID,
+                    name = SEARCH_USER_NAME,
+                    email = null,
+                    handle = SEARCH_USER_HANDLE,
+                    teamId = null,
+                    supportedProtocols = emptyList(),
+                    deleted = null
+                )
+            )
             coEvery {
-                searchApiClient.searchUsers(
+                userService.searchUsers(
                     query = SEARCH_QUERY,
                     domain = SEARCH_DOMAIN,
                     numberOfResults = SEARCH_NUMBER_OF_RESULTS
                 )
-            } returns expectedResponse
+            } returns expectedUsers
 
             val manager = WireApplicationManager(
-                teamStorage = teamStorage,
-                backendClient = backendClient,
+                teamStorage = mockk(relaxed = true),
+                backendClient = mockk(relaxed = true),
                 userService = userService,
-                mlsApiClient = mlsApiClient,
-                assetsApiClient = assetsApiClient,
-                searchApiClient = searchApiClient,
-                cryptoClient = cryptoClient,
-                mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                mlsApiClient = mockk(relaxed = true),
+                assetsApiClient = mockk(relaxed = true),
+                cryptoClient = mockk(relaxed = true),
+                mlsFallbackStrategy = mockk(relaxed = true),
+                conversationService = mockk(relaxed = true)
             )
 
             // Act
@@ -588,14 +581,40 @@ class WireApplicationManagerTest {
             )
 
             // Assert
-            assertEquals(expectedResponse, result)
+            assertEquals(expectedUsers, result)
             coVerify(exactly = 1) {
-                searchApiClient.searchUsers(
+                userService.searchUsers(
                     query = SEARCH_QUERY,
                     domain = SEARCH_DOMAIN,
                     numberOfResults = SEARCH_NUMBER_OF_RESULTS
                 )
             }
+        }
+
+    @Test
+    fun `when searchUsers returns empty list, then returns empty list`() =
+        runTest {
+            val userService = mockk<UserService>(relaxed = true)
+            coEvery { userService.searchUsers(any(), any(), any()) } returns emptyList()
+
+            val manager = WireApplicationManager(
+                teamStorage = mockk(relaxed = true),
+                backendClient = mockk(relaxed = true),
+                userService = userService,
+                mlsApiClient = mockk(relaxed = true),
+                assetsApiClient = mockk(relaxed = true),
+                cryptoClient = mockk(relaxed = true),
+                mlsFallbackStrategy = mockk(relaxed = true),
+                conversationService = mockk(relaxed = true)
+            )
+
+            val result = manager.searchUsersSuspending(
+                query = SEARCH_QUERY,
+                domain = SEARCH_DOMAIN,
+                numberOfResults = null
+            )
+
+            assertTrue(result.isEmpty())
         }
 
     private suspend fun generateUser2Packages(): List<KeyPackage> =
@@ -783,14 +802,12 @@ class WireApplicationManagerTest {
         private const val SEARCH_QUERY = "Alice"
         private const val SEARCH_DOMAIN = "wire.com"
         private const val SEARCH_NUMBER_OF_RESULTS = 25
-        private val SEARCH_CONTACTS_RESPONSE = SearchContactsResponse(
-            documents = emptyList(),
-            found = 0,
-            hasMore = false,
-            pagingState = null,
-            returned = 0,
-            took = 5
+        private val SEARCH_USER_QUALIFIED_ID = QualifiedId(
+            id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            domain = "wire.com"
         )
+        private const val SEARCH_USER_NAME = "Alice"
+        private const val SEARCH_USER_HANDLE = "alice"
 
         @JvmStatic
         @BeforeAll

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -27,7 +27,6 @@ import com.wire.sdk.client.AssetsApiClient
 import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.client.SearchApiClient
-import com.wire.sdk.client.UsersApiClient
 import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.crypto.MlsCryptoClient
@@ -352,7 +351,7 @@ class WireApplicationManagerTest {
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
             coEvery { mlsApiClient.sendMessage(any()) } returns Unit
 
-            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
             val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
@@ -365,7 +364,7 @@ class WireApplicationManagerTest {
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
                 backendClient = backendClient,
-                usersApiClient = usersApiClient,
+                userService = userService,
                 mlsApiClient = mlsApiClient,
                 assetsApiClient = assetsApiClient,
                 searchApiClient = searchApiClient,
@@ -431,7 +430,7 @@ class WireApplicationManagerTest {
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
             coEvery { mlsApiClient.sendMessage(any()) } returns Unit
 
-            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
             val searchApiClient = mockk<SearchApiClient>(relaxed = true)
 
@@ -444,7 +443,7 @@ class WireApplicationManagerTest {
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
                 backendClient = backendClient,
-                usersApiClient = usersApiClient,
+                userService = userService,
                 assetsApiClient = assetsApiClient,
                 searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
@@ -508,7 +507,7 @@ class WireApplicationManagerTest {
                 conversationEntity
 
             val backendClient = mockk<BackendClient>(relaxed = true)
-            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
             val searchApiClient = mockk<SearchApiClient>(relaxed = true)
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
@@ -519,7 +518,7 @@ class WireApplicationManagerTest {
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
                 backendClient = backendClient,
-                usersApiClient = usersApiClient,
+                userService = userService,
                 assetsApiClient = assetsApiClient,
                 searchApiClient = searchApiClient,
                 mlsApiClient = mlsApiClient,
@@ -553,7 +552,7 @@ class WireApplicationManagerTest {
             val conversationService = mockk<ConversationService>(relaxed = true)
             val backendClient = mockk<BackendClient>(relaxed = true)
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
-            val usersApiClient = mockk<UsersApiClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
             val searchApiClient = mockk<SearchApiClient>(relaxed = true)
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
@@ -572,7 +571,7 @@ class WireApplicationManagerTest {
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
                 backendClient = backendClient,
-                usersApiClient = usersApiClient,
+                userService = userService,
                 mlsApiClient = mlsApiClient,
                 assetsApiClient = assetsApiClient,
                 searchApiClient = searchApiClient,

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/CustomWireEventsHandler.java
@@ -159,7 +159,7 @@ public class CustomWireEventsHandler extends WireEventsHandlerDefault {
         logger.info("User(s) joined conversation. conversationId: {}, membersCount: {}", conversationId, members.size());
         members.forEach(member -> {
             try {
-                final var name = getManager().getUser(member.userId()).getName();
+                final var name = getManager().getUser(member.userId()).name();
                 welcomeTheNewJoiner(conversationId, name);
             } catch (WireException e) {
                 throw new RuntimeException(e);

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/callbacks/GreetNewJoinerInConversationExample.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/callbacks/GreetNewJoinerInConversationExample.java
@@ -39,7 +39,7 @@ public class GreetNewJoinerInConversationExample extends WireEventsHandlerDefaul
         logger.info("User(s) joined conversation. conversationId: {}, membersCount: {}", conversationId, members.size());
         members.forEach(member -> {
             try {
-                final var name = getManager().getUser(member.userId()).getName();
+                final var name = getManager().getUser(member.userId()).name();
                 welcomeTheNewJoiner(conversationId, name);
             } catch (WireException e) {
                 throw new RuntimeException(e);

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -244,33 +244,38 @@ class TestCommandProcessor {
                     "⚠️ Usage: search-user [queryString]  (e.g. search-user alex)",
                     List.of(), List.of(), null)
             );
-
             return;
         }
 
         final var query = split[1].trim();
-        final var response = this.manager.searchUsers(query, wireMessage.sender().domain(), 100);
+        final var users = this.manager.searchUsers(query, wireMessage.sender().domain(), 100);
 
         final var sb = new StringBuilder();
-        sb.append("Search results for \"").append(query).append("\" ")
-                .append("(").append(response.getReturned() != null ? response.getReturned() : 0)
-                .append(" of ").append(response.getFound() != null ? response.getFound() : 0)
-                .append(" found):\n\n");
+        sb.append("🔍 Search results for \"").append(query).append("\" ")
+                .append("(").append(users.size()).append(" found):\n\n");
 
-        if (response.getDocuments().isEmpty()) {
+        if (users.isEmpty()) {
             sb.append("No users found.");
         } else {
-            for (final var doc : response.getDocuments()) {
-                sb.append("👉").append(doc.getName());
-                if (doc.getHandle() != null) {
-                    sb.append(" (@").append(doc.getHandle()).append(")");
+            for (final var user : users) {
+                sb.append("👤 ").append(user.name());
+
+                if (user.handle() != null) {
+                    sb.append(" (@").append(user.handle()).append(")");
                 }
-                if (doc.getQualifiedId() != null) {
-                    sb.append(", ID: ").append("`").append(doc.getQualifiedId().id()).append("`")
-                            .append(" @ ").append(doc.getQualifiedId().domain());
+
+                sb.append("\n   ID: ").append(user.id().id())
+                        .append(" @ ").append(user.id().domain());
+
+                if (user.teamId() != null) {
+                    sb.append("\n   Team: ").append(user.teamId());
                 }
-                sb.append(", team: ").append(doc.getTeam());
-                sb.append("\n");
+
+                if (user.email() != null) {
+                    sb.append("\n   Email: ").append(user.email());
+                }
+
+                sb.append("\n\n");
             }
         }
 

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -405,27 +405,26 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
         }
 
         val query = split[1].trim()
-        val response = manager.searchUsersSuspending(
+        val users = manager.searchUsersSuspending(
             query = query,
             domain = wireMessage.sender.domain,
             numberOfResults = 100
         )
 
         val sb = StringBuilder()
-        sb.append("Search results for \"$query\" ")
-            .append("(${response.returned ?: 0} of ${response.found ?: "?"} found):\n\n")
+        sb.append("🔍 Search results for \"$query\" ")
+            .append("(${users.size} found):\n\n")
 
-        if (response.documents.isEmpty()) {
+        if (users.isEmpty()) {
             sb.append("No users found.")
         } else {
-            response.documents.forEach { doc ->
-                sb.append("👉 ${doc.name}")
-                doc.handle?.let { sb.append(" (@$it)") }
-                doc.qualifiedId?.let {
-                    sb.append(", ID: `${it.id}` @ ${it.domain}")
-                }
-                doc.team?.let { sb.append(", team: $it") }
-                sb.append("\n")
+            users.forEach { user ->
+                sb.append("👤 ${user.name}")
+                user.handle?.let { sb.append(" (@$it)") }
+                sb.append("\n   ID: ${user.id.id} @ ${user.id.domain}")
+                user.teamId?.let { sb.append("\n   Team: $it") }
+                user.email?.let { sb.append("\n   Email: $it") }
+                sb.append("\n\n")
             }
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
The response of getUser and searchUsers methods are very different than each other and this causes extra work and confusion for developers. 

### Solutions

Introduce WireUser class and use it for the return values of getUser and searchUsers methods

### Testing
#### How to Test

Run the sample and verify existing test commands to test the results.
