### PR TITLE
chore: Bump SDK version to 0.2.0-alpha

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,3 @@
 object Versions {
-    const val SDK_VERSION = "0.1.0"
+    const val SDK_VERSION = "0.2.0-alpha"
 }


### PR DESCRIPTION
Bump SDK version to 0.2.0-alpha before releasing a new SDK version