### PR TITLE
chore: Update Wire SDK version to 0.2.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,3 @@
 object Versions {
-    const val SDK_VERSION = "0.2.0-alpha"
+    const val SDK_VERSION = "0.2.0"
 }


### PR DESCRIPTION
Bump JVM SDK version to 0.2.0 before releasing a new JVM SDK version