### PR TITLE
chore: Update Samples to support testing multiple user addition on group creation

### DIFF
--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -63,10 +63,17 @@ class TestCommandProcessor {
     }
 
     private void processCreateGroupConversation(WireMessage.Text wireMessage) {
-        // Expected message: `create-group-conversation [NAME] [USER_ID] [DOMAIN]`
+        // Expected message: `create-group-conversation [NAME] [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
         final var split = wireMessage.text().split(" ");
-        final var userIds = List.of(new QualifiedId(UUID.fromString(split[2]), split[3]));
-        this.manager.createGroupConversation(split[1], userIds);
+
+        final var name = split[1];
+        final var userIds = new ArrayList<QualifiedId>();
+
+        for (int i = 2; i + 1 < split.length; i += 2) {
+            userIds.add(new QualifiedId(UUID.fromString(split[i]), split[i + 1]));
+        }
+
+        this.manager.createGroupConversation(name, userIds);
     }
 
     private void processLeaveGroupConversation(WireMessage.Text wireMessage) {
@@ -80,10 +87,17 @@ class TestCommandProcessor {
     }
 
     private void processCreateChannelConversation(WireMessage.Text wireMessage) {
-        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN]`
+        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
         final var split = wireMessage.text().split(" ");
-        final var userIds = List.of(new QualifiedId(UUID.fromString(split[2]), split[3]));
-        this.manager.createChannelConversation(split[1], userIds);
+
+        final var name = split[1];
+        final var userIds = new ArrayList<QualifiedId>();
+
+        for (int i = 2; i + 1 < split.length; i += 2) {
+            userIds.add(new QualifiedId(UUID.fromString(split[i]), split[i + 1]));
+        }
+
+        this.manager.createChannelConversation(name, userIds);
     }
 
     private void processAddMemberInConversation(WireMessage.Text wireMessage) {

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -295,17 +295,17 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
     }
 
     private suspend fun processCreateGroupConversation(wireMessage: WireMessage.Text) {
-        // Expected message: `create-group-conversation [NAME] [USER_ID] [DOMAIN]`
+        // Expected message: `create-group-conversation [NAME] [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
         val split = wireMessage.text.split(" ")
+
+        val userIds = split.drop(2)
+            .chunked(2)
+            .filter { it.size == 2 }
+            .map { (id, domain) -> QualifiedId(id = UUID.fromString(id), domain = domain) }
 
         val conversationId = manager.createGroupConversationSuspending(
             name = split[1],
-            userIds = listOf(
-                QualifiedId(
-                    id = UUID.fromString(split[2]),
-                    domain = split[3]
-                )
-            )
+            userIds = userIds
         )
 
         manager.updateConversationMemberRole(
@@ -326,17 +326,17 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
     }
 
     private suspend fun processCreateChannelConversation(wireMessage: WireMessage.Text) {
-        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN]`
+        // Expected message: `create-channel-conversation [NAME] [USER_ID] [DOMAIN] [USER_ID] [DOMAIN] ...`
         val split = wireMessage.text.split(" ")
+
+        val userIds = split.drop(2)
+            .chunked(2)
+            .filter { it.size == 2 }
+            .map { (id, domain) -> QualifiedId(id = UUID.fromString(id), domain = domain) }
 
         manager.createChannelConversationSuspending(
             name = split[1],
-            userIds = listOf(
-                QualifiedId(
-                    id = UUID.fromString(split[2]),
-                    domain = split[3]
-                )
-            )
+            userIds = userIds
         )
     }
 


### PR DESCRIPTION
Update Samples to support testing multiple user addition on group/channel creation

Example usage is: 
`create-group-conversation [group_name] [user-1-id] [user-1-domain] [user-2-id] [user-2-domain] ....` 
`create-channel-conversation [channel_name] [user-1-id] [user-1-domain] [user-2-id] [user-2-domain] .... `