### PR TITLE
fix: Avoid adding Asset-Token header if the token received is an empty string #WPB-27168

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/client/AssetsApiClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/AssetsApiClient.kt
@@ -48,7 +48,7 @@ internal class AssetsApiClient(private val httpClient: HttpClient) {
         logger.info("Downloading asset ${assetId.obfuscateId()}")
 
         return httpClient.prepareGet("/$BASE_PATH/$assetDomain/$assetId") {
-            assetToken?.let { header(HEADER_ASSET_TOKEN, it) }
+            if (!assetToken.isNullOrBlank()) header(HEADER_ASSET_TOKEN, assetToken)
         }.execute { httpResponse ->
             httpResponse.readRawBytes()
         }

--- a/lib/src/test/kotlin/com/wire/sdk/client/AssetsApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/AssetsApiClientTest.kt
@@ -81,6 +81,15 @@ class AssetsApiClientTest {
         }
 
     @Test
+    fun `when downloadAsset with blank token, then Asset-Token header is absent`() =
+        runTest {
+            var capturedHeaders: io.ktor.http.Headers? = null
+            apiClient(responseBody = FAKE_BYTES) { capturedHeaders = it.headers }
+                .downloadAsset(ASSET_ID, ASSET_DOMAIN, assetToken = "")
+            assertEquals(null, capturedHeaders?.get("Asset-Token"))
+        }
+
+    @Test
     fun `when uploadAsset, then correct URL`() =
         runTest {
             var capturedPath: String? = null


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SDK could not download assets anymore

### Solutions

Avoid http header for asset token if it's just an empty string (resulting in 404)

#### How to Test

Send an asset in a group where there is an App that downloads all assets received

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
