### PR TITLE
feat: Delete crypto folder and deviceId, when cookie no longer works

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/client/AuthTokenManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/AuthTokenManager.kt
@@ -73,7 +73,13 @@ class AuthTokenManager(private val appStorage: AppStorage) {
         } catch (ex: WireException.ClientError) {
             logger.error("Unable to retrieve access token, Error: ${ex.message}")
             if (ex.response.isCredentialsInvalid()) {
+                // The cookie is no longer valid for the stored (temporary) client. Clear both so
+                // that on the next restart the SDK registers a fresh client. The associated
+                // cryptography keystore is wiped at startup in getOrInitCryptoClient, which is the
+                // only point where no CoreCrypto client holds the keystore open.
+                logger.error("Removing current cookie and deviceId from storage")
                 appStorage.deleteBackendCookie()
+                appStorage.deleteDeviceId()
             }
             // TODO Can't recover from this, need to restart the app with a valid api token
             error("Current cookie/api-token is expired. Get a apiToken and restart the App")

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -309,14 +309,14 @@ internal suspend fun getOrInitCryptoClient(
 
     val appId = IsolatedKoinContext.getApplicationUser().id
 
-    val cryptoClient = MlsCryptoClient.create(
-        appId = appId,
-        ciphersuiteCode = mlsCipherSuiteCode
-    )
-
     val storedDeviceId = appStorage.getDeviceId()
-    if (storedDeviceId != null) {
+
+    return if (storedDeviceId != null) {
         logger.info("Loading MLS Client for: ${storedDeviceId.obfuscateClientId()}")
+        val cryptoClient = MlsCryptoClient.create(
+            appId = appId,
+            ciphersuiteCode = mlsCipherSuiteCode
+        )
         val cryptoClientId = CryptoClientId.create(
             appId = appId,
             deviceId = storedDeviceId,
@@ -328,9 +328,21 @@ internal suspend fun getOrInitCryptoClient(
             mlsTransport = mlsTransport
         )
         appStorage.setShouldRejoinConversations(should = false)
+        cryptoClient
     } else {
         // App doesn't have a client, create one
         logger.info("Initializing Proteus Client")
+
+        // No registered client: either a fresh install, or a previous client was invalidated
+        // (invalid-credentials) and its deviceId cleared. Wipe any stale keystore so CoreCrypto
+        // starts from a clean state. Safe here as no CoreCrypto client has the keystore open yet.
+        val wiped = MlsCryptoClient.deleteClientStorage(appId)
+        logger.info("No registered client found, cleared any stale keystore (success={})", wiped)
+
+        val cryptoClient = MlsCryptoClient.create(
+            appId = appId,
+            ciphersuiteCode = mlsCipherSuiteCode
+        )
         cryptoClient.initializeProteusClient()
         val preKeys = cryptoClient.generateProteusPreKeys()
         val lastKey = cryptoClient.generateProteusLastPreKey()
@@ -379,7 +391,6 @@ internal suspend fun getOrInitCryptoClient(
         )
 
         appStorage.setShouldRejoinConversations(should = true)
+        cryptoClient
     }
-
-    return cryptoClient
 }

--- a/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
@@ -289,16 +289,36 @@ internal class MlsCryptoClient private constructor(
     companion object {
         private const val DEFAULT_CIPHERSUITE_IDENTIFIER = 1
         private const val KEYSTORE_NAME = "keystore"
+        private const val CLIENT_STORAGE_ROOT = "storage/cryptography"
+
+        /**
+         * Local directory holding the CoreCrypto keystore (Proteus + MLS state) for [appId].
+         */
+        fun clientStorageDirectory(appId: UUID): File = File("$CLIENT_STORAGE_ROOT/$appId")
+
+        /**
+         * Deletes the local CoreCrypto keystore directory for [appId], wiping all Proteus and
+         * MLS state so a new client can be registered from a clean slate.
+         *
+         * Must only be called while no CoreCrypto client holds the keystore open (e.g. at
+         * startup before [create]); deleting an open keystore leads to undefined behaviour.
+         *
+         * @return true if the directory was absent or fully deleted, false if deletion failed.
+         */
+        fun deleteClientStorage(appId: UUID): Boolean {
+            val directory = clientStorageDirectory(appId)
+            return if (directory.exists()) directory.deleteRecursively() else true
+        }
 
         suspend fun create(
             appId: UUID,
             ciphersuiteCode: Int = DEFAULT_CIPHERSUITE_IDENTIFIER
         ): MlsCryptoClient {
-            val clientDirectoryPath = "storage/cryptography/$appId"
-            val keystorePath = "$clientDirectoryPath/$KEYSTORE_NAME"
+            val clientDirectory = clientStorageDirectory(appId)
+            val keystorePath = "${clientDirectory.path}/$KEYSTORE_NAME"
             val ciphersuite = getMlsCipherSuiteName(ciphersuiteCode)
 
-            File(clientDirectoryPath).mkdirs()
+            clientDirectory.mkdirs()
 
             val coreCryptoClient = CoreCrypto.invoke(
                 keystore = keystorePath,

--- a/lib/src/main/kotlin/com/wire/sdk/persistence/AppSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/persistence/AppSqlLiteStorage.kt
@@ -58,6 +58,8 @@ class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
 
     override fun saveDeviceId(deviceId: String) = save(DEVICE_ID, deviceId)
 
+    override fun deleteDeviceId() = delete(DEVICE_ID)
+
     override fun getBackendCookie(): String? =
         runCatching {
             val encryptedBytes = Base64.getDecoder().decode(getByKey(BACKEND_COOKIE).value)

--- a/lib/src/main/kotlin/com/wire/sdk/persistence/AppStorage.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/persistence/AppStorage.kt
@@ -37,6 +37,8 @@ interface AppStorage {
 
     fun saveDeviceId(deviceId: String)
 
+    fun deleteDeviceId()
+
     fun getBackendCookie(): String?
 
     fun saveBackendCookie(cookie: String)

--- a/lib/src/test/kotlin/com/wire/sdk/client/AuthTokenManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/AuthTokenManagerTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.wire.sdk.TestUtils.TEST_API_VERSION
+import com.wire.sdk.config.IsolatedKoinContext
+import com.wire.sdk.config.createHttpClient
+import com.wire.sdk.persistence.AppStorage
+import io.ktor.client.plugins.auth.providers.RefreshTokensParams
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class AuthTokenManagerTest {
+    private val appStorage = mockk<AppStorage>()
+    private val httpClient = createHttpClient(wireMockServer.baseUrl(), mockk())
+
+    @BeforeEach
+    fun resetStubs() {
+        wireMockServer.resetAll()
+        every { appStorage.getBackendCookie() } returns "cookie"
+        every { appStorage.getDeviceId() } returns "device"
+        justRun { appStorage.deleteBackendCookie() }
+        justRun { appStorage.deleteDeviceId() }
+    }
+
+    @Test
+    fun `when access returns invalid-credentials, then cookie and deviceId are deleted`() =
+        runTest {
+            stubAccess(label = "invalid-credentials")
+            val authTokenManager = AuthTokenManager(appStorage)
+
+            assertFailsWith<IllegalStateException> {
+                authTokenManager.refreshAccessToken(refreshParams())
+            }
+
+            verify(exactly = 1) { appStorage.deleteBackendCookie() }
+            verify(exactly = 1) { appStorage.deleteDeviceId() }
+        }
+
+    @Test
+    fun `when access returns a non credentials 403, then nothing is deleted`() =
+        runTest {
+            stubAccess(label = "operation-denied")
+            val authTokenManager = AuthTokenManager(appStorage)
+
+            assertFailsWith<IllegalStateException> {
+                authTokenManager.refreshAccessToken(refreshParams())
+            }
+
+            verify(exactly = 0) { appStorage.deleteBackendCookie() }
+            verify(exactly = 0) { appStorage.deleteDeviceId() }
+        }
+
+    private fun stubAccess(label: String) {
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo("/$TEST_API_VERSION/access"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(403)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"code":403,"label":"$label","message":"forbidden"}""")
+                )
+        )
+    }
+
+    // relaxed = true so the member-extension markAsRefreshTokenRequest() is a no-op in the test
+    private fun refreshParams(): RefreshTokensParams =
+        mockk<RefreshTokensParams>(relaxed = true).also {
+            every { it.client } returns httpClient
+        }
+
+    companion object {
+        private val wireMockServer = WireMockServer(8087)
+
+        @JvmStatic
+        @BeforeAll
+        fun before() {
+            IsolatedKoinContext.start()
+            wireMockServer.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun after() {
+            wireMockServer.stop()
+            IsolatedKoinContext.stop()
+        }
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
@@ -52,6 +52,33 @@ class MlsCryptoClientTest {
     }
 
     @Test
+    fun deleteClientStorageRemovesKeystoreDirectory() {
+        runBlocking {
+            val userId = UUID.randomUUID()
+            val cryptoClient = MlsCryptoClient.create(
+                appId = userId,
+                ciphersuiteCode = 1
+            )
+            cryptoClient.close()
+
+            val directory = MlsCryptoClient.clientStorageDirectory(userId)
+            assertTrue { directory.exists() }
+
+            val deleted = MlsCryptoClient.deleteClientStorage(userId)
+
+            assertTrue { deleted }
+            assertFalse { directory.exists() }
+        }
+    }
+
+    @Test
+    fun deleteClientStorageReturnsTrueWhenDirectoryMissing() {
+        val userId = UUID.randomUUID()
+        assertFalse { MlsCryptoClient.clientStorageDirectory(userId).exists() }
+        assertTrue { MlsCryptoClient.deleteClientStorage(userId) }
+    }
+
+    @Test
     fun testMlsClientFailOnDifferentPassword() {
         runBlocking {
             val userId = UUID.randomUUID()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There were cases where an invalid cookie was deleted, but when the app restarted with a new cookie, it still had the previous temporary client. If a new client was created by another pod or a human, the app stayed dead in a loop

### Causes (Optional)

App could not restart even with a proper cookie

### Solutions

Remove deviceId from apps.db and check for absence on the next start, deleting the crypto-folder just in case, prompting for complete recreation of the client


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Run the app, then with TM refresh the cookie. The app will fail on the next accessToken refresh.
Then wait for it to stop and check apps.db.

Set the new cookie in the env vars and check that crypto folder is deleted and recreated and then the app works

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
