### PR TITLE
chore: Log obfuscated api token before it is saved.

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/WireAppSdk.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/WireAppSdk.kt
@@ -24,6 +24,7 @@ import com.wire.sdk.service.conversation.ConversationService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.koin.dsl.module
+import com.wire.sdk.utils.obfuscateId
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.UUID
@@ -125,8 +126,12 @@ class WireAppSdk(
         val appStorage = IsolatedKoinContext.koinApp.koin.get<AppStorage>()
         val existingCookie = appStorage.getBackendCookie()
         if (existingCookie == null) {
-            logger.info("Storing API token in AppStorage")
+            logger.info(
+                "No API token found. Storing API token in AppStorage. " +
+                    "apiToken:${apiToken.obfuscateId()}"
+            )
             appStorage.saveBackendCookie(apiToken)
+            logger.info("API token is stored in AppStorage. apiToken:${apiToken.obfuscateId()}")
         } else {
             logger.info("API token already stored in AppStorage (initial apiToken or a refresh)")
         }

--- a/lib/src/main/kotlin/com/wire/sdk/client/AuthTokenManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/client/AuthTokenManager.kt
@@ -18,6 +18,7 @@ package com.wire.sdk.client
 
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.persistence.AppStorage
+import com.wire.sdk.utils.obfuscateId
 import io.ktor.client.call.body
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.RefreshTokensParams
@@ -44,8 +45,15 @@ class AuthTokenManager(private val appStorage: AppStorage) {
         if (responseCookies.isNotEmpty()) {
             val newCookie = responseCookies.firstOrNull { it.name == "zuid" }?.value
             if (!newCookie.isNullOrBlank()) {
+                logger.info(
+                    "Refresh access token. Storing API token in AppStorage. " +
+                        "apiToken:${newCookie.obfuscateId()}"
+                )
                 appStorage.saveBackendCookie(newCookie)
-                logger.info("Received new api token from backend, updated stored cookie")
+                logger.info(
+                    "Refreshed API token is stored in AppStorage. " +
+                        "apiToken:${newCookie.obfuscateId()}"
+                )
             }
         }
 


### PR DESCRIPTION
Log obfuscated API token value. So that we will be able to see first 7 characters in case we need to compare what we currently have in database or in the environment variables.