### PR TITLE
feat: Let control msg types be sent to ephemeral conversation

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/exception/WireException.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/exception/WireException.kt
@@ -61,12 +61,6 @@ sealed class WireException @JvmOverloads constructor(
     ) : WireException(message ?: throwable?.localizedMessage, throwable) {
         companion object {
             const val DEFAULT_MESSAGE = "One or more parameters are invalid."
-
-            fun messageIsNotEphemeral() =
-                InvalidParameter(
-                    "Message type is not ephemeral. " +
-                        "Cannot be sent to ephemeral conversation."
-                )
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -192,30 +192,18 @@ class WireApplicationManager internal constructor(
         conversation: ConversationEntity,
         originalMessage: WireMessage
     ): WireMessage {
-        val preparedMessage =
-            if (conversation.messageTimer != null) {
-                if (originalMessage is WireMessage.Ephemeral) {
-                    originalMessage.overrideExpirationDuration(conversation.messageTimer)
-                        .also {
-                            logger.info(
-                                "Setting (overriding) expiration duration of the message " +
-                                    "${conversation.id} to ${conversation.messageTimer} ms"
-                            )
-                        }
-                } else {
-                    logger.warn(
-                        "Message ${originalMessage.id} is not ephemeral but the conversation " +
-                            "${conversation.id} has a message timer set. " +
-                            "The message can not be sent."
-                    )
+        if (conversation.messageTimer == null || originalMessage !is WireMessage.Ephemeral) {
+            return originalMessage
+        }
 
-                    throw WireException.InvalidParameter.messageIsNotEphemeral()
-                }
-            } else {
-                originalMessage
+        return originalMessage.overrideExpirationDuration(conversation.messageTimer)
+            .also {
+                logger.info(
+                    "Setting (overriding) expiration duration of the message " +
+                        "${originalMessage.id} in conversation ${conversation.id} " +
+                        "to ${conversation.messageTimer} ms"
+                )
             }
-
-        return preparedMessage
     }
 
     private fun WireMessage.Ephemeral.overrideExpirationDuration(expiresAfter: Long): WireMessage =

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -481,7 +481,7 @@ class WireApplicationManagerTest {
         }
 
     @Test
-    fun `throws when conversation has messageTimer and message is not ephemeral`() =
+    fun `non-ephemeral message is sent unmodified when conversation has messageTimer`() =
         runTest {
             // Arrange
             val conversationId = QualifiedId(UUID.randomUUID(), "example.com")
@@ -504,8 +504,13 @@ class WireApplicationManagerTest {
             val backendClient = mockk<BackendClient>(relaxed = true)
             val userService = mockk<UserService>(relaxed = true)
             val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+
             val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
+            coEvery { mlsApiClient.sendMessage(any()) } returns Unit
+
             val cryptoClient = mockk<CryptoClient>(relaxed = true)
+            coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(4)
+
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
 
@@ -532,10 +537,229 @@ class WireApplicationManagerTest {
                 emojiSet = setOf("🙂")
             )
 
-            // Act & Assert
-            assertThrows<WireException.InvalidParameter> {
-                manager.sendMessageSuspending(reaction)
+            mockkObject(ProtobufSerializer)
+            val captured = slot<WireMessage>()
+            every { ProtobufSerializer.toGenericMessageByteArray(capture(captured)) } answers {
+                byteArrayOf(5)
             }
+
+            // Act
+            val resultId = manager.sendMessageSuspending(reaction)
+
+            // Assert
+            assertEquals(reaction.id, resultId)
+            assertEquals(reaction.id, captured.captured.id)
+
+            coVerify(exactly = 1) { cryptoClient.encryptMls(any(), any()) }
+            coVerify(exactly = 1) { mlsApiClient.sendMessage(any()) }
+        }
+
+    @Test
+    fun `non-ephemeral message is sent unmodified when conversation has no messageTimer`() =
+        runTest {
+            // Arrange
+            val conversationId = QualifiedId(UUID.randomUUID(), "example.com")
+            val mlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+
+            val conversationEntity = ConversationEntity(
+                id = conversationId,
+                name = "test",
+                teamId = null,
+                mlsGroupId = mlsGroupId,
+                type = ConversationEntity.Type.GROUP,
+                messageTimer = null
+            )
+
+            val conversationService = mockk<ConversationService>(relaxed = true)
+            coEvery { conversationService.getConversationById(conversationId) } returns
+                conversationEntity
+
+            val backendClient = mockk<BackendClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
+            val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+
+            val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
+            coEvery { mlsApiClient.sendMessage(any()) } returns Unit
+
+            val cryptoClient = mockk<CryptoClient>(relaxed = true)
+            coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(6)
+
+            val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
+            val teamStorage = mockk<TeamStorage>(relaxed = true)
+
+            val manager = WireApplicationManager(
+                teamStorage = teamStorage,
+                backendClient = backendClient,
+                userService = userService,
+                assetsApiClient = assetsApiClient,
+                mlsApiClient = mlsApiClient,
+                cryptoClient = cryptoClient,
+                mlsFallbackStrategy = mlsFallbackStrategy,
+                conversationService = conversationService
+            )
+
+            val originalMessage = WireMessage.Text.create(
+                conversationId = conversationId,
+                text = "base",
+                expiresAfterMillis = null
+            )
+            val reaction = WireMessage.Reaction.create(
+                originalMessage = originalMessage,
+                emojiSet = setOf("👍")
+            )
+
+            mockkObject(ProtobufSerializer)
+            val captured = slot<WireMessage>()
+            every { ProtobufSerializer.toGenericMessageByteArray(capture(captured)) } answers {
+                byteArrayOf(7)
+            }
+
+            // Act
+            val resultId = manager.sendMessageSuspending(reaction)
+
+            // Assert
+            assertEquals(reaction.id, resultId)
+            assertEquals(reaction.id, captured.captured.id)
+
+            coVerify(exactly = 1) { cryptoClient.encryptMls(any(), any()) }
+            coVerify(exactly = 1) { mlsApiClient.sendMessage(any()) }
+        }
+
+    @Test
+    fun `existing expiresAfterMillis is overridden by conversation messageTimer`() =
+        runTest {
+            // Arrange
+            val conversationId = QualifiedId(UUID.randomUUID(), "example.com")
+            val mlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+
+            val messageTimerValue = 5_000L
+            val conversationEntity = ConversationEntity(
+                id = conversationId,
+                name = "test",
+                teamId = null,
+                mlsGroupId = mlsGroupId,
+                type = ConversationEntity.Type.GROUP,
+                messageTimer = messageTimerValue
+            )
+
+            val conversationService = mockk<ConversationService>(relaxed = true)
+            coEvery { conversationService.getConversationById(conversationId) } returns
+                conversationEntity
+
+            val backendClient = mockk<BackendClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
+            val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+
+            val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
+            coEvery { mlsApiClient.sendMessage(any()) } returns Unit
+
+            val cryptoClient = mockk<CryptoClient>(relaxed = true)
+            coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(8)
+
+            val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
+            val teamStorage = mockk<TeamStorage>(relaxed = true)
+
+            val manager = WireApplicationManager(
+                teamStorage = teamStorage,
+                backendClient = backendClient,
+                userService = userService,
+                assetsApiClient = assetsApiClient,
+                mlsApiClient = mlsApiClient,
+                cryptoClient = cryptoClient,
+                mlsFallbackStrategy = mlsFallbackStrategy,
+                conversationService = conversationService
+            )
+
+            // Message already has its OWN expiry set, different from the conversation's timer
+            val originalMessage = WireMessage.Text.create(
+                conversationId = conversationId,
+                text = "already ephemeral",
+                expiresAfterMillis = 60_000L
+            )
+
+            mockkObject(ProtobufSerializer)
+            val captured = slot<WireMessage>()
+            every { ProtobufSerializer.toGenericMessageByteArray(capture(captured)) } answers {
+                byteArrayOf(9)
+            }
+
+            // Act
+            manager.sendMessageSuspending(originalMessage)
+
+            // Assert: conversation's messageTimer wins over the message's own value
+            val expires = (captured.captured as WireMessage.Text).expiresAfterMillis
+            assertEquals(messageTimerValue, expires)
+
+            coVerify(exactly = 1) { cryptoClient.encryptMls(any(), any()) }
+            coVerify(exactly = 1) { mlsApiClient.sendMessage(any()) }
+        }
+
+    @Test
+    fun `expiration is overridden for a non-Text ephemeral message type`() =
+        runTest {
+            // Arrange
+            val conversationId = QualifiedId(UUID.randomUUID(), "example.com")
+            val mlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+
+            val messageTimerValue = 15_000L
+            val conversationEntity = ConversationEntity(
+                id = conversationId,
+                name = "test",
+                teamId = null,
+                mlsGroupId = mlsGroupId,
+                type = ConversationEntity.Type.GROUP,
+                messageTimer = messageTimerValue
+            )
+
+            val conversationService = mockk<ConversationService>(relaxed = true)
+            coEvery { conversationService.getConversationById(conversationId) } returns
+                conversationEntity
+
+            val backendClient = mockk<BackendClient>(relaxed = true)
+            val userService = mockk<UserService>(relaxed = true)
+            val assetsApiClient = mockk<AssetsApiClient>(relaxed = true)
+
+            val mlsApiClient = mockk<MlsApiClient>(relaxed = true)
+            coEvery { mlsApiClient.sendMessage(any()) } returns Unit
+
+            val cryptoClient = mockk<CryptoClient>(relaxed = true)
+            coEvery { cryptoClient.encryptMls(any(), any()) } returns byteArrayOf(10)
+
+            val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
+            val teamStorage = mockk<TeamStorage>(relaxed = true)
+
+            val manager = WireApplicationManager(
+                teamStorage = teamStorage,
+                backendClient = backendClient,
+                userService = userService,
+                assetsApiClient = assetsApiClient,
+                mlsApiClient = mlsApiClient,
+                cryptoClient = cryptoClient,
+                mlsFallbackStrategy = mlsFallbackStrategy,
+                conversationService = conversationService
+            )
+
+            // Use Ping instead of Text to prove the override isn't Text-specific
+            val originalMessage = WireMessage.Ping.create(
+                conversationId = conversationId,
+                expiresAfterMillis = null
+            )
+
+            mockkObject(ProtobufSerializer)
+            val captured = slot<WireMessage>()
+            every { ProtobufSerializer.toGenericMessageByteArray(capture(captured)) } answers {
+                byteArrayOf(11)
+            }
+
+            // Act
+            manager.sendMessageSuspending(originalMessage)
+
+            // Assert
+            val expires = (captured.captured as WireMessage.Ping).expiresAfterMillis
+            assertEquals(messageTimerValue, expires)
+
+            coVerify(exactly = 1) { cryptoClient.encryptMls(any(), any()) }
+            coVerify(exactly = 1) { mlsApiClient.sendMessage(any()) }
         }
 
     @Test

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
@@ -29,7 +29,11 @@ public enum TestCommand {
     ASSET_VIDEO("asset-video"),
     ASSET_PDF_DOCUMENT("asset-document-pdf"),
     SEARCH_USER("search-user"),
-    TEST_DELETED_MESSAGE("test-deleted-message");
+    TEST_DELETED_MESSAGE("test-deleted-message"),
+    SEND_EPHEMERAL_TEXT("send-ephemeral-text"),
+    SEND_EPHEMERAL_PING("send-ephemeral-ping"),
+    SEND_LOCATION_MESSAGE("send-location-message"),
+    SEND_EPHEMERAL_LOCATION_MESSAGE("send-ephemeral-location-message");
 
     private final String commandStr;
 

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommand.java
@@ -28,7 +28,8 @@ public enum TestCommand {
     ASSET_AUDIO("asset-audio"),
     ASSET_VIDEO("asset-video"),
     ASSET_PDF_DOCUMENT("asset-document-pdf"),
-    SEARCH_USER("search-user");
+    SEARCH_USER("search-user"),
+    TEST_DELETED_MESSAGE("test-deleted-message");
 
     private final String commandStr;
 

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -22,6 +22,8 @@ import com.wire.sdk.model.WireMessage;
 import com.wire.sdk.model.asset.AssetRetention;
 import com.wire.sdk.service.WireApplicationManager;
 
+import kotlin.time.Clock;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -31,6 +33,8 @@ import java.util.List;
 import java.util.UUID;
 
 class TestCommandProcessor {
+
+    private static final long EPHEMERAL_MSG_EXPIRE_MILLIS = 10_000L;
 
     private final WireApplicationManager manager;
 
@@ -54,6 +58,11 @@ class TestCommandProcessor {
             case ASSET_PDF_DOCUMENT -> replyWithSamplePDFDocument(wireMessage);
             case SEARCH_USER -> processSearchUser(wireMessage);
             case TEST_DELETED_MESSAGE -> processTestDeletedMessage(wireMessage);
+            case SEND_EPHEMERAL_TEXT -> processSendEphemeralText(wireMessage);
+            case SEND_EPHEMERAL_PING -> processSendEphemeralPing(wireMessage);
+            case SEND_LOCATION_MESSAGE -> processSendLocationMessage(wireMessage);
+            case SEND_EPHEMERAL_LOCATION_MESSAGE ->
+                    processSendEphemeralLocationMessage(wireMessage);
         }
     }
 
@@ -321,6 +330,46 @@ class TestCommandProcessor {
         this.manager.sendMessage(WireMessage.Deleted.create(
                 wireMessage.conversationId(),
                 messageId));
+    }
+
+    private void processSendEphemeralText(WireMessage.Text wireMessage) {
+        // Expected message: `send-ephemeral-text`
+        this.manager.sendMessage(WireMessage.Text.create(
+                wireMessage.conversationId(),
+                "This is an Ephemeral Text message",
+                List.of(), List.of(),
+                EPHEMERAL_MSG_EXPIRE_MILLIS));
+    }
+
+    private void processSendEphemeralPing(WireMessage.Text wireMessage) {
+        // Expected message: `send-ephemeral-ping`
+        this.manager.sendMessage(WireMessage.Ping.create(
+                wireMessage.conversationId(),
+                EPHEMERAL_MSG_EXPIRE_MILLIS));
+    }
+
+    private void processSendLocationMessage(WireMessage.Text wireMessage) {
+        // Expected message: `send-location-message`
+        this.manager.sendMessage(WireMessage.Location.create(
+                wireMessage.conversationId(),
+                52.52527f,
+                13.36923f,
+                "Berlin Hauptbahnhof, 10557 Berlin",
+                50,
+                Clock.System.INSTANCE.now(),
+                null));
+    }
+
+    private void processSendEphemeralLocationMessage(WireMessage.Text wireMessage) {
+        // Expected message: `send-ephemeral-location-message`
+        this.manager.sendMessage(WireMessage.Location.create(
+                wireMessage.conversationId(),
+                52.51615f,
+                13.37827f,
+                "Pariser Platz, 10117 Berlin",
+                50,
+                Clock.System.INSTANCE.now(),
+                EPHEMERAL_MSG_EXPIRE_MILLIS));
     }
 
 }

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/testcommand/TestCommandProcessor.java
@@ -46,12 +46,14 @@ class TestCommandProcessor {
             case DELETE_GROUP_CONVERSATION -> processDeleteGroupConversation(wireMessage);
             case CREATE_CHANNEL_CONVERSATION -> processCreateChannelConversation(wireMessage);
             case ADD_MEMBER_IN_CONVERSATION -> processAddMemberInConversation(wireMessage);
-            case REMOVE_MEMBER_FROM_CONVERSATION -> processRemoveMemberFromConversation(wireMessage);
+            case REMOVE_MEMBER_FROM_CONVERSATION ->
+                    processRemoveMemberFromConversation(wireMessage);
             case ASSET_IMAGE -> processAssetImage(wireMessage);
             case ASSET_AUDIO -> processAssetAudio(wireMessage);
             case ASSET_VIDEO -> processAssetVideo(wireMessage);
             case ASSET_PDF_DOCUMENT -> replyWithSamplePDFDocument(wireMessage);
             case SEARCH_USER -> processSearchUser(wireMessage);
+            case TEST_DELETED_MESSAGE -> processTestDeletedMessage(wireMessage);
         }
     }
 
@@ -127,8 +129,8 @@ class TestCommandProcessor {
 
         if (!members.isEmpty()) {
             this.manager.removeMembersFromConversation(
-                wireMessage.conversationId(),
-                members
+                    wireMessage.conversationId(),
+                    members
             );
         }
     }
@@ -297,6 +299,28 @@ class TestCommandProcessor {
                 wireMessage.conversationId(),
                 sb.toString(),
                 List.of(), List.of(), null));
+    }
+
+    private void processTestDeletedMessage(WireMessage.Text wireMessage) {
+        // Expected message: `test-deleted-message`
+        // Sends a text message and then deletes it after 3 seconds.
+        final var message = WireMessage.Text.create(
+                wireMessage.conversationId(),
+                "This message will be deleted in 3 seconds",
+                List.of(), List.of(), null);
+
+        final var messageId = this.manager.sendMessage(message);
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        this.manager.sendMessage(WireMessage.Deleted.create(
+                wireMessage.conversationId(),
+                messageId));
     }
 
 }

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/SampleEventsHandler.kt
@@ -95,11 +95,36 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
             return
         }
 
+        if (isTestDeletedMessage(text = wireMessage.text)) {
+            processTestDeletedMessage(wireMessage = wireMessage)
+            return
+        }
+
+        if (isSendEphemeralText(text = wireMessage.text)) {
+            processSendEphemeralText(wireMessage = wireMessage)
+            return
+        }
+
+        if (isSendEphemeralPing(text = wireMessage.text)) {
+            processSendEphemeralPing(wireMessage = wireMessage)
+            return
+        }
+
+        if (isSendLocationMessage(text = wireMessage.text)) {
+            processSendLocationMessage(wireMessage = wireMessage)
+            return
+        }
+
+        if (isSendEphemeralLocationMessage(text = wireMessage.text)) {
+            processSendEphemeralLocationMessage(wireMessage = wireMessage)
+            return
+        }
+
         // Sends an Ephemeral message if received message is Ephemeral
         wireMessage.expiresAfterMillis?.let {
             val ephemeralMessage = WireMessage.Text.create(
                 conversationId = wireMessage.conversationId,
-                text = "${wireMessage.text} -- Ephemeral Message sent from the SDK",
+                text = "${wireMessage.text} -- Ephemeral Message sent from the Sample-Kotlin App",
                 mentions = wireMessage.mentions,
                 expiresAfterMillis = 10_000
             )
@@ -109,7 +134,7 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
         }
 
         val message = WireMessage.Text.createReply(
-            text = "${wireMessage.text} -- Sent from the SDK",
+            text = "${wireMessage.text} -- Sent from the Sample-Kotlin App",
             mentions = wireMessage.mentions,
             originalMessage = wireMessage
         )
@@ -235,6 +260,21 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
 
     private fun isSearchUser(text: String): Boolean =
         text.startsWith("search-user")
+
+    private fun isTestDeletedMessage(text: String): Boolean =
+        text.startsWith("test-deleted-message")
+
+    private fun isSendEphemeralText(text: String): Boolean =
+        text.startsWith("send-ephemeral-text")
+
+    private fun isSendEphemeralPing(text: String): Boolean =
+        text.startsWith("send-ephemeral-ping")
+
+    private fun isSendLocationMessage(text: String): Boolean =
+        text.startsWith("send-location-message")
+
+    private fun isSendEphemeralLocationMessage(text: String): Boolean =
+        text.startsWith("send-ephemeral-location-message")
 
     private suspend fun processAddMembersToConversation(wireMessage: WireMessage.Text) {
         // Expected message: `add-members-to-conversation [USER_ID] [DOMAIN]
@@ -451,5 +491,77 @@ class SampleEventsHandler : WireEventsHandlerSuspending() {
             mimeType = "application/pdf",
             retention = AssetRetention.VOLATILE
         )
+    }
+
+    private suspend fun processTestDeletedMessage(wireMessage: WireMessage.Text) {
+        // Expected message: `test-deleted-message`
+        // Sends a text message and then deletes it after 3 seconds.
+        val message = WireMessage.Text.create(
+            conversationId = wireMessage.conversationId,
+            text = "This message will be deleted in 3 seconds"
+        )
+
+        val messageId = manager.sendMessageSuspending(message = message)
+
+        delay(3000L)
+
+        manager.sendMessageSuspending(
+            message = WireMessage.Deleted.create(
+                conversationId = wireMessage.conversationId,
+                messageId = messageId
+            )
+        )
+    }
+
+    private suspend fun processSendEphemeralText(wireMessage: WireMessage.Text) {
+        // Expected message: `send-ephemeral-text`
+        manager.sendMessageSuspending(
+            message = WireMessage.Text.create(
+                conversationId = wireMessage.conversationId,
+                text = "This is an Ephemeral Text message",
+                expiresAfterMillis = EPHEMERAL_MSG_EXPIRE_MILLIS
+            )
+        )
+    }
+
+    private suspend fun processSendEphemeralPing(wireMessage: WireMessage.Text) {
+        // Expected message: `send-ephemeral-ping`
+        manager.sendMessageSuspending(
+            message = WireMessage.Ping.create(
+                conversationId = wireMessage.conversationId,
+                expiresAfterMillis = EPHEMERAL_MSG_EXPIRE_MILLIS
+            )
+        )
+    }
+
+    private suspend fun processSendLocationMessage(wireMessage: WireMessage.Text) {
+        // Expected message: `send-location-message`
+        manager.sendMessageSuspending(
+            message = WireMessage.Location.create(
+                conversationId = wireMessage.conversationId,
+                latitude = 52.52527f,
+                longitude = 13.36923f,
+                name = "Berlin Hauptbahnhof, 10557 Berlin",
+                zoom = 50
+            )
+        )
+    }
+
+    private suspend fun processSendEphemeralLocationMessage(wireMessage: WireMessage.Text) {
+        // Expected message: `send-ephemeral-location-message`
+        manager.sendMessageSuspending(
+            message = WireMessage.Location.create(
+                conversationId = wireMessage.conversationId,
+                latitude = 52.51615f,
+                longitude = 13.37827f,
+                name = "Pariser Platz, 10117 Berlin",
+                zoom = 50,
+                expiresAfterMillis = EPHEMERAL_MSG_EXPIRE_MILLIS
+            )
+        )
+    }
+
+    private companion object {
+        private const val EPHEMERAL_MSG_EXPIRE_MILLIS = 10_000L
     }
 }


### PR DESCRIPTION
After the latest alignments, we learnt that the control message types (such as DeleteMessage) can be sent in ephemeral conversations even though these message types are not ephemeral. 
Related document is also updated with this info. 