### PR TITLE
feat: Add device id getter in application manager (WPB-27557)

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -139,7 +139,7 @@ val sdkModule =
 
         // Manager
         single {
-            WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get())
+            WireApplicationManager(get(), get(), get(), get(), get(), get(), get(), get(), get())
         }
     }
 

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -33,6 +33,7 @@ import com.wire.sdk.model.asset.AssetRetention
 import com.wire.sdk.model.asset.AssetUploadData
 import com.wire.sdk.model.conversation.AddMembersToConversationResult
 import com.wire.sdk.model.http.ApiVersionResponse
+import com.wire.sdk.persistence.AppStorage
 import com.wire.sdk.model.http.conversation.ConversationRole
 import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
@@ -62,7 +63,8 @@ class WireApplicationManager internal constructor(
     private val assetsApiClient: AssetsApiClient,
     private val cryptoClient: CryptoClient,
     private val mlsFallbackStrategy: MlsFallbackStrategy,
-    private val conversationService: ConversationService
+    private val conversationService: ConversationService,
+    private val appStorage: AppStorage
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -682,4 +684,11 @@ class WireApplicationManager internal constructor(
             domain = domain,
             numberOfResults = numberOfResults
         )
+
+    /**
+     * Returns the device id of application
+     *
+     * Note: This reads from local storage and does not make any network request.
+     */
+    fun getDeviceId(): String? = appStorage.getDeviceId()
 }

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -41,6 +41,7 @@ import com.wire.sdk.model.protobuf.ProtobufSerializer
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
 import com.wire.sdk.utils.MlsTransportLastWelcome
+import com.wire.sdk.persistence.AppStorage
 import io.ktor.http.HttpStatusCode
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -358,6 +359,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -367,7 +369,8 @@ class WireApplicationManagerTest {
                 assetsApiClient = assetsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             val originalMessage = WireMessage.Text.create(
@@ -435,6 +438,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -444,7 +448,8 @@ class WireApplicationManagerTest {
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             val originalMessage = WireMessage.Text.create(
@@ -513,6 +518,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -522,7 +528,8 @@ class WireApplicationManagerTest {
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             val originalMessage = WireMessage.Text.create(
@@ -586,6 +593,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -595,7 +603,8 @@ class WireApplicationManagerTest {
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             val originalMessage = WireMessage.Text.create(
@@ -658,6 +667,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -667,7 +677,8 @@ class WireApplicationManagerTest {
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             // Message already has its OWN expiry set, different from the conversation's timer
@@ -727,6 +738,7 @@ class WireApplicationManagerTest {
 
             val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
             val teamStorage = mockk<TeamStorage>(relaxed = true)
+            val appStorage = mockk<AppStorage>(relaxed = true)
 
             val manager = WireApplicationManager(
                 teamStorage = teamStorage,
@@ -736,7 +748,8 @@ class WireApplicationManagerTest {
                 mlsApiClient = mlsApiClient,
                 cryptoClient = cryptoClient,
                 mlsFallbackStrategy = mlsFallbackStrategy,
-                conversationService = conversationService
+                conversationService = conversationService,
+                appStorage = appStorage
             )
 
             // Use Ping instead of Text to prove the override isn't Text-specific
@@ -793,7 +806,8 @@ class WireApplicationManagerTest {
                 assetsApiClient = mockk(relaxed = true),
                 cryptoClient = mockk(relaxed = true),
                 mlsFallbackStrategy = mockk(relaxed = true),
-                conversationService = mockk(relaxed = true)
+                conversationService = mockk(relaxed = true),
+                appStorage = mockk(relaxed = true)
             )
 
             // Act
@@ -828,7 +842,8 @@ class WireApplicationManagerTest {
                 assetsApiClient = mockk(relaxed = true),
                 cryptoClient = mockk(relaxed = true),
                 mlsFallbackStrategy = mockk(relaxed = true),
-                conversationService = mockk(relaxed = true)
+                conversationService = mockk(relaxed = true),
+                appStorage = mockk(relaxed = true)
             )
 
             val result = manager.searchUsersSuspending(
@@ -838,6 +853,30 @@ class WireApplicationManagerTest {
             )
 
             assertTrue(result.isEmpty())
+        }
+
+    @Test
+    fun `when device id is requested, should return the value from app storage`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { getDeviceId() } returns DEVICE_ID
+            }
+
+            val manager = WireApplicationManager(
+                teamStorage = mockk(relaxed = true),
+                backendClient = mockk(relaxed = true),
+                userService = mockk(relaxed = true),
+                mlsApiClient = mockk(relaxed = true),
+                assetsApiClient = mockk(relaxed = true),
+                cryptoClient = mockk(relaxed = true),
+                mlsFallbackStrategy = mockk(relaxed = true),
+                conversationService = mockk(relaxed = true),
+                appStorage = appStorage
+            )
+
+            val deviceId = manager.getDeviceId()
+
+            assertEquals(DEVICE_ID, deviceId)
         }
 
     private suspend fun generateUser2Packages(): List<KeyPackage> =
@@ -853,6 +892,7 @@ class WireApplicationManagerTest {
         }
 
     companion object {
+        private const val DEVICE_ID = "device-id-123"
         private val wireMockServer = WireMockServer(8086)
         private val testMlsTransport = MlsTransportLastWelcome()
         private lateinit var newPackages: List<KeyPackage>


### PR DESCRIPTION
Join by Phone application will need device id in order to initialize AVS. Provide a helper function in application manager for this purpose.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Provide device id to sdk users

### Solutions

Adda getter in application manager

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution
