### PR TITLE
feat: Get message sender from core-crypto after decryption, instead of the backend value #WPB-27779

### DIFF
--- a/lib/src/main/kotlin/com/wire/sdk/crypto/CryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/CryptoClient.kt
@@ -36,7 +36,7 @@ internal interface CryptoClient : AutoCloseable {
     suspend fun decryptMls(
         mlsGroupId: ConversationId,
         encryptedMessage: String
-    ): ByteArray?
+    ): DecryptedMlsMessage
 
     /**
      * Proteus Configuration

--- a/lib/src/main/kotlin/com/wire/sdk/crypto/DecryptedMlsMessage.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/DecryptedMlsMessage.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.crypto
+
+internal data class DecryptedMlsMessage(
+    val message: ByteArray?,
+    val senderClientId: String?
+)

--- a/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/crypto/MlsCryptoClient.kt
@@ -17,8 +17,8 @@ import com.wire.crypto.Welcome
 import com.wire.crypto.invoke
 import com.wire.crypto.toClientId
 import com.wire.crypto.toExternalSenderKey
+import com.wire.crypto.use
 import com.wire.sdk.config.IsolatedKoinContext
-import com.wire.sdk.crypto.MlsCryptoClient.Companion.create
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.CryptoClientId
 import com.wire.sdk.model.http.MlsPublicKeys
@@ -65,7 +65,7 @@ internal class MlsCryptoClient private constructor(
     override suspend fun decryptMls(
         mlsGroupId: ConversationId,
         encryptedMessage: String
-    ): ByteArray? {
+    ): DecryptedMlsMessage {
         val encryptedMessageBytes: ByteArray = Base64.decode(encryptedMessage)
         val decryptedMessage =
             coreCryptoClient.transaction {
@@ -74,7 +74,14 @@ internal class MlsCryptoClient private constructor(
                     payload = encryptedMessageBytes
                 )
             }
-        return decryptedMessage.message
+        return decryptedMessage.use { dm ->
+            DecryptedMlsMessage(
+                message = dm.message,
+                senderClientId = dm.senderClientId
+                    ?.copyBytes()
+                    ?.toString(Charsets.UTF_8)
+            )
+        }
     }
 
     override suspend fun initializeProteusClient() =

--- a/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory
 
 // TODO This class is connected to too many services. Should keep only the concurrency and
 //  routing logic, and delegate the core crypto + backend operations to 1-2 other services.
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class EventsRouter internal constructor(
     private val teamStorage: TeamStorage,
     private val conversationService: ConversationService,
@@ -233,15 +233,24 @@ internal class EventsRouter internal constructor(
                     )
 
                     logger.debug("Decryption successful")
-                    if (message == null) {
+                    if (message.message == null || message.senderClientId == null) {
                         logger.debug("Decryption success but no message, probably epoch update")
                         return
                     }
 
+                    val sender = parseSenderClientId(message.senderClientId)
+                    if (sender != event.qualifiedFrom) {
+                        logger.error(
+                            "MLS message sender {} does not match event envelope sender {}",
+                            sender,
+                            event.qualifiedFrom
+                        )
+                    }
+
                     forwardMessage(
-                        message = message,
+                        message = message.message,
                         conversationId = event.qualifiedConversation,
-                        sender = event.qualifiedFrom,
+                        sender = sender,
                         timestamp = event.time
                     )
                 } catch (exception: MlsException) {
@@ -418,6 +427,17 @@ internal class EventsRouter internal constructor(
         } else {
             NON_CONVERSATION_EVENTS
         }
+    }
+
+    private fun parseSenderClientId(senderClientId: String): QualifiedId {
+        val clientIdParts = senderClientId.split(':')
+        val parts = clientIdParts[1]
+            .split('@')
+            .takeIf { it.size == 2 && it.all(String::isNotBlank) }
+            ?: throw IllegalArgumentException(
+                "Invalid senderClientId format: $senderClientId"
+            )
+        return QualifiedId(id = UUID.fromString(clientIdParts[0]), domain = parts[1])
     }
 
     private suspend fun handleWelcomeEvent(

--- a/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/crypto/MlsCryptoClientTest.kt
@@ -160,7 +160,7 @@ class MlsCryptoClientTest {
             )
             bobClient.initializeMlsClient(
                 cryptoClientId = CryptoClientId(
-                    value = "bob_$bobUserId"
+                    value = "$bobUserId:bob-client@wire.test"
                 ),
                 mlsTransport = testMlsTransport
             )
@@ -172,7 +172,7 @@ class MlsCryptoClientTest {
             )
             aliceClient.initializeMlsClient(
                 cryptoClientId = CryptoClientId(
-                    value = "alice_$aliceUserId"
+                    value = "$aliceUserId:alice-client@wire.test"
                 ),
                 mlsTransport = testMlsTransport
             )
@@ -210,9 +210,10 @@ class MlsCryptoClientTest {
             val encryptedBase64Message = Base64.getEncoder().encodeToString(encryptedMessage)
 
             // Bob decrypts the message
-            val decrypted: ByteArray? = bobClient.decryptMls(mlsGroupId, encryptedBase64Message)
+            val decrypted = bobClient.decryptMls(mlsGroupId, encryptedBase64Message)
+            assertEquals("$aliceUserId:alice-client@wire.test", decrypted.senderClientId)
 
-            val genericMessage = GenericMessage.parseFrom(decrypted)
+            val genericMessage = GenericMessage.parseFrom(decrypted.message)
             val wireMessage = ProtobufDeserializer.processGenericMessage(
                 genericMessage = genericMessage,
                 conversationId = QualifiedId(

--- a/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
@@ -16,12 +16,17 @@
 
 package com.wire.sdk.service
 
+import com.wire.crypto.ConversationId
+import com.wire.sdk.WireEventsHandler
 import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.client.ConversationsApiClient
 import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.crypto.CryptoClient
+import com.wire.sdk.crypto.DecryptedMlsMessage
 import com.wire.sdk.model.ConversationMember
+import com.wire.sdk.model.ConversationEntity
 import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.WireMessage
 import com.wire.sdk.model.http.EventContentDTO
 import com.wire.sdk.model.http.EventResponse
 import com.wire.sdk.model.http.conversation.ConversationRole
@@ -29,6 +34,7 @@ import com.wire.sdk.model.http.conversation.Member
 import com.wire.sdk.model.http.conversation.MemberJoinEventData
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
+import com.wire.sdk.utils.MockCoreCryptoClient
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -54,6 +60,63 @@ import kotlin.time.Clock
  * - Channel isolation prevents cross-conversation failures
  */
 class EventsRouterConcurrencyTest {
+    @Test
+    fun `MLS message sender comes from decrypted sender client ID`() =
+        runTest {
+            val conversationId = QualifiedId(UUID.randomUUID(), "wire.test")
+            val decryptedSender = QualifiedId(UUID.randomUUID(), "sender.wire.test")
+            val envelopeSender = QualifiedId(UUID.randomUUID(), "envelope.wire.test")
+            val mlsGroupId = ConversationId(UUID.randomUUID().toString().toByteArray())
+            val conversation = ConversationEntity(
+                id = conversationId,
+                name = null,
+                teamId = null,
+                mlsGroupId = mlsGroupId,
+                type = ConversationEntity.Type.GROUP
+            )
+            val conversationService = mockk<ConversationService>()
+            val cryptoClient = mockk<CryptoClient>()
+            var receivedSender: QualifiedId? = null
+            val wireEventsHandler = object : WireEventsHandlerSuspending() {
+                override suspend fun onTextMessageReceived(wireMessage: WireMessage.Text) {
+                    receivedSender = wireMessage.sender
+                }
+            }
+
+            coEvery { conversationService.getConversationById(conversationId) } returns conversation
+            coEvery { cryptoClient.decryptMls(mlsGroupId, any()) } returns DecryptedMlsMessage(
+                message = MockCoreCryptoClient.GENERIC_TEXT_MESSAGE.toByteArray(),
+                senderClientId = "${decryptedSender.id}:client@${decryptedSender.domain}"
+            )
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val eventsRouter = createEventsRouter(
+                conversationService = conversationService,
+                cryptoClient = cryptoClient,
+                wireEventsHandler = wireEventsHandler,
+                dispatcher = testDispatcher
+            )
+
+            eventsRouter.route(
+                EventResponse(
+                    id = UUID.randomUUID().toString(),
+                    payload = listOf(
+                        EventContentDTO.Conversation.NewMLSMessageDTO(
+                            qualifiedConversation = conversationId,
+                            qualifiedFrom = envelopeSender,
+                            time = Clock.System.now(),
+                            data = "encrypted-message",
+                            subconversation = null
+                        )
+                    )
+                )
+            )
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(decryptedSender, receivedSender)
+            eventsRouter.close()
+        }
+
     @Test
     fun `events for same conversation are processed in order`() =
         runTest {
@@ -462,9 +525,9 @@ class EventsRouterConcurrencyTest {
         conversationsApiClient: ConversationsApiClient = mockk(relaxed = true),
         mlsApiClient: MlsApiClient = mockk(relaxed = true),
         cryptoClient: CryptoClient = mockk(relaxed = true),
+        wireEventsHandler: WireEventsHandler = object : WireEventsHandlerSuspending() {},
         dispatcher: CoroutineDispatcher = Dispatchers.Default
     ): EventsRouter {
-        val wireEventsHandler = object : WireEventsHandlerSuspending() {}
         val mlsFallbackStrategy = mockk<MlsFallbackStrategy>(relaxed = true)
 
         return EventsRouter(

--- a/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
@@ -30,6 +30,7 @@ import com.wire.crypto.Welcome
 import com.wire.crypto.invoke
 import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
+import com.wire.sdk.crypto.DecryptedMlsMessage
 import com.wire.sdk.model.CryptoClientId
 import com.wire.sdk.model.http.MlsPublicKeys
 import com.wire.sdk.model.http.client.PreKeyCrypto
@@ -89,7 +90,11 @@ internal class MockCoreCryptoClient private constructor(
     override suspend fun decryptMls(
         mlsGroupId: ConversationId,
         encryptedMessage: String
-    ): ByteArray = GENERIC_TEXT_MESSAGE.toByteArray()
+    ): DecryptedMlsMessage =
+        DecryptedMlsMessage(
+            message = GENERIC_TEXT_MESSAGE.toByteArray(),
+            senderClientId = DEFAULT_SENDER_CLIENT_ID
+        )
 
     // Throw OrphanWelcome, testing the fallback to createJoinMlsConversationRequest
     override suspend fun processWelcomeMessage(welcome: Welcome): ConversationId =
@@ -197,6 +202,8 @@ internal class MockCoreCryptoClient private constructor(
 
         private const val DEFAULT_CIPHERSUITE_IDENTIFIER = 1
         private const val KEYSTORE_NAME = "keystore"
+        private const val DEFAULT_SENDER_CLIENT_ID =
+            "00000000-0000-0000-0000-000000000001:mock-client@wire.test"
         val MLS_GROUP_ID = ConversationId(UUID.randomUUID().toString().toByteArray())
         val MLS_GROUP_ID_BASE64 = Base64.getEncoder().encodeToString(MLS_GROUP_ID.copyBytes())
         val GENERIC_TEXT_MESSAGE: GenericMessage = GenericMessage


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sender was fetched by the backend data (could be spoofed)

### Solutions

Instead get message sender from MLS message, which is E2EE and therefore more reliable/secure


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
