### PR TITLE
feat: Remove appId from startup parameters #WPB-27663

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Within `lib/`, a few paths are especially important when making changes:
 ### Local runtime notes
 
 - The SDK creates and uses a repository-root `storage/` directory for SQLite state and cryptographic material.
-- If you switch backend environments or `applicationId`, a stale `storage/` directory can break local runs. Clean or move it when debugging environment-specific issues.
+- If you switch backend environments or application tokens, a stale `storage/` directory can break local runs. Clean or move it when debugging environment-specific issues.
 
 ## Architecture
 
@@ -79,7 +79,7 @@ Within `lib/`, a few paths are especially important when making changes:
 
 Operational details that matter when modifying these APIs:
 
-- `WireAppSdk` is initialized with `applicationId`, `apiToken`, `apiHost`, `cryptographyStoragePassword`, and a `WireEventsHandler` implementation.
+- `WireAppSdk` is initialized with `apiToken`, `apiHost`, `cryptographyStoragePassword`, and a `WireEventsHandler` implementation.
 - `cryptographyStoragePassword` must be 32 characters.
 - `WireAppSdk.startListening()` starts the WebSocket listener in a background thread.
 - `WireAppSdk.stopListening()` stops the listener.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Wire Apps JVM SDK - An SDK for building Wire third-party applications in Kotlin/
 ### Core Components
 
 **WireAppSdk** (`lib/src/main/kotlin/com/wire/sdk/WireAppSdk.kt`)
-- Main entry point. Initialize with applicationId, apiToken, apiHost, cryptographyStoragePassword (must be 32 chars), and a WireEventsHandler implementation.
+- Main entry point. Initialize with apiToken, apiHost, cryptographyStoragePassword (must be 32 chars), and a WireEventsHandler implementation.
 - `startListening()` starts WebSocket connection in background thread
 - `stopListening()` shuts down the connection
 - `getApplicationManager()` returns WireApplicationManager for API operations

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ dependencies {
 
 ## Troubleshooting
 
-If you have started using the SDK targeting one Wire environment or you have switched `applicationId`,
+If you have started using the SDK targeting one Wire environment or you have switched Api Token (apiToken),
 and later you want to switch to another, you may need to move/delete the `storage` directory to have a clean start.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,7 +14,6 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import java.util.UUID
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
@@ -241,12 +240,19 @@ tasks {
     build {
         dependsOn(shadowJar)
     }
+}
 
-    /**
-     * Dummy environment variables for tests
-     */
-    test {
-        environment("WIRE_SDK_USER_ID", UUID.randomUUID().toString())
-        environment("WIRE_SDK_PASSWORD", "randomPassword")
-    }
+tasks.withType<Test> {
+    afterSuite(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ desc, result ->
+            if (desc.parent == null) {
+                println(
+                    "Tests: ${result.testCount}, " +
+                        "Passed: ${result.successfulTestCount}, " +
+                        "Failed: ${result.failedTestCount}, " +
+                        "Skipped: ${result.skippedTestCount}"
+                )
+            }
+        })
+    )
 }

--- a/lib/src/main/kotlin/com/wire/sdk/WireAppSdk.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/WireAppSdk.kt
@@ -27,7 +27,6 @@ import org.koin.dsl.module
 import com.wire.sdk.utils.obfuscateId
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -42,7 +41,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Example usage:
  * ```kotlin
  * val sdk = WireAppSdk(
- *     applicationId = UUID.fromString("your-app-id"),
  *     apiToken = "your-api-token",
  *     apiHost = "https://prod-nginz-https.wire.com",
  *     cryptographyStorageKey = yourSecureKey, // 32 bytes
@@ -60,7 +58,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  * - HTTP client calls to the Wire backend API
  * - Local storage for conversation and team data
  *
- * @property applicationId The unique identifier for your Wire application
  * @property apiToken The API token for authenticating with the Wire backend
  * @property apiHost The Wire backend API host URL (e.g., "https://prod-nginz-https.wire.com")
  * @property cryptographyStorageKey A 32-byte key used to encrypt the local cryptographic storage.
@@ -71,7 +68,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @throws IllegalArgumentException if [cryptographyStorageKey] is not exactly 32 bytes
  */
 class WireAppSdk(
-    applicationId: UUID,
     apiToken: String,
     apiHost: String,
     cryptographyStorageKey: ByteArray,
@@ -93,7 +89,6 @@ class WireAppSdk(
         initializeStorageDirectory()
 
         IsolatedKoinContext.start()
-        IsolatedKoinContext.setApplicationId(applicationId)
         IsolatedKoinContext.setApiHost(apiHost)
         IsolatedKoinContext.setCryptographyStorageKey(cryptographyStorageKey.copyOf())
 

--- a/lib/src/main/kotlin/com/wire/sdk/config/IsolatedKoinContext.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/IsolatedKoinContext.kt
@@ -15,19 +15,14 @@
 
 package com.wire.sdk.config
 
-import com.wire.sdk.model.QualifiedId
 import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.dsl.koinApplication
 import org.koin.fileProperties
-import java.util.UUID
 
 @Suppress("TooManyFunctions")
 internal object IsolatedKoinContext {
     private var _koinApp: KoinApplication? = null
-
-    @Volatile
-    private var _applicationUser: QualifiedId? = null
 
     val koinApp: KoinApplication
         get() = _koinApp ?: error("Koin not started")
@@ -44,33 +39,12 @@ internal object IsolatedKoinContext {
             modules(sdkModule)
             fileProperties("/koin-sdk.properties")
         }
-
-        clearCachedApplicationUser()
     }
 
     fun stop() {
         _koinApp?.close()
         _koinApp = null
-        clearCachedApplicationUser()
     }
-
-    fun setApplicationId(value: UUID) {
-        this.koinApp.koin.setProperty(APPLICATION_ID, value)
-        clearCachedApplicationUser()
-    }
-
-    fun getApplicationUser(): QualifiedId =
-        _applicationUser ?: synchronized(this) {
-            _applicationUser ?: run {
-                val id = checkNotNull(koinApp.koin.getProperty<UUID>(APPLICATION_ID)) {
-                    "App ID is not set in Koin properties"
-                }
-                val domain = checkNotNull(koinApp.koin.getProperty<String>(BACKEND_DOMAIN)) {
-                    "Wire Backend domain is not set in Koin properties"
-                }
-                QualifiedId(id = id, domain = domain).also { _applicationUser = it }
-            }
-        }
 
     fun setApiHost(value: String) {
         this.koinApp.koin.setProperty(API_HOST, value)
@@ -90,25 +64,9 @@ internal object IsolatedKoinContext {
             "Cryptography Storage Key is not set in Koin properties"
         }
 
-    fun getBackendDomain(): String =
-        checkNotNull(this.koinApp.koin.getProperty(BACKEND_DOMAIN)) {
-            "Backend domain is not set in Koin properties"
-        }
-
-    fun setBackendDomain(value: String) {
-        this.koinApp.koin.setProperty(BACKEND_DOMAIN, value)
-        clearCachedApplicationUser()
-    }
-
-    private fun clearCachedApplicationUser() {
-        _applicationUser = null
-    }
-
     /**
      * Property Constants
      */
-    private const val APPLICATION_ID = "APPLICATION_ID"
     private const val API_HOST = "API_HOST"
     private const val CRYPTOGRAPHY_STORAGE_KEY = "CRYPTOGRAPHY_STORAGE_KEY"
-    private const val BACKEND_DOMAIN = "BACKEND_DOMAIN"
 }

--- a/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/config/Modules.kt
@@ -54,6 +54,7 @@ import com.wire.sdk.service.UserService
 import com.wire.sdk.service.WireApplicationManager
 import com.wire.sdk.service.WireTeamEventsListener
 import com.wire.sdk.service.conversation.ConversationService
+import com.wire.sdk.service.self.SelfService
 import com.wire.sdk.utils.KtxSerializer
 import com.wire.sdk.utils.mls
 import com.wire.sdk.utils.obfuscateClientId
@@ -107,15 +108,16 @@ val sdkModule =
         single<MlsApiClient> { MlsApiClient(get(), get()) }
         single<MlsTransport> { MlsTransportImpl(get()) }
         single<MlsFallbackStrategy> { MlsFallbackStrategy(get(), get()) }
-        single { EventsRouter(get(), get(), get(), get(), get(), get(), get()) } onClose
+        single { EventsRouter(get(), get(), get(), get(), get(), get(), get(), get()) } onClose
             { it?.close() }
         single<AuthTokenManager> { AuthTokenManager(get()) }
         single<HttpClient> {
             createHttpClient(IsolatedKoinContext.getApiHost(), get())
         } onClose { it?.close() }
+        single { SelfService(get(), get()) }
         single<CryptoClient> {
             runBlocking {
-                getOrInitCryptoClient(get(), get(), get(), get(), get())
+                getOrInitCryptoClient(get(), get(), get(), get(), get(), get())
             }
         } onClose { it?.close() }
         single { WireTeamEventsListener(get(), get(), get(), get()) }
@@ -123,7 +125,6 @@ val sdkModule =
         // Services
         single {
             ConversationService(
-                get(),
                 get(),
                 get(),
                 get(),
@@ -291,36 +292,34 @@ private fun initializeDatabase(dbUrl: String): SqlDriver {
  *
  * The following times the SDK is started, the client will be loaded from the storage.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 internal suspend fun getOrInitCryptoClient(
     backendClient: BackendClient,
     clientsApiClient: ClientsApiClient,
     mlsApiClient: MlsApiClient,
+    selfService: SelfService,
     appStorage: AppStorage,
     mlsTransport: MlsTransport
 ): CryptoClient {
     val mlsCipherSuiteCode = backendClient.getApplicationFeatures()
         .mlsFeatureResponse.mlsFeatureConfigResponse.defaultCipherSuite
 
-    // Fetch and store the backend domain from the api-version endpoint
-    val backendDomain = backendClient.getAvailableApiVersions().domain
-    IsolatedKoinContext.setBackendDomain(backendDomain)
-    logger.info("Retrieved Wire backend domain: $backendDomain")
-
-    val appId = IsolatedKoinContext.getApplicationUser().id
+    // Fetch and store the application QualifiedId
+    selfService.fetchAndSaveApplicationData()
+    val applicationQualifiedId = appStorage.getApplicationQualifiedId()
+    logger.info("Retrieved Wire backend domain: ${applicationQualifiedId.domain}")
 
     val storedDeviceId = appStorage.getDeviceId()
 
     return if (storedDeviceId != null) {
         logger.info("Loading MLS Client for: ${storedDeviceId.obfuscateClientId()}")
         val cryptoClient = MlsCryptoClient.create(
-            appId = appId,
+            appId = applicationQualifiedId.id,
             ciphersuiteCode = mlsCipherSuiteCode
         )
         val cryptoClientId = CryptoClientId.create(
-            appId = appId,
-            deviceId = storedDeviceId,
-            userDomain = backendDomain
+            applicationQualifiedId = applicationQualifiedId,
+            deviceId = storedDeviceId
         )
         // App has a client, load MLS client
         cryptoClient.initializeMlsClient(
@@ -336,11 +335,11 @@ internal suspend fun getOrInitCryptoClient(
         // No registered client: either a fresh install, or a previous client was invalidated
         // (invalid-credentials) and its deviceId cleared. Wipe any stale keystore so CoreCrypto
         // starts from a clean state. Safe here as no CoreCrypto client has the keystore open yet.
-        val wiped = MlsCryptoClient.deleteClientStorage(appId)
+        val wiped = MlsCryptoClient.deleteClientStorage(applicationQualifiedId.id)
         logger.info("No registered client found, cleared any stale keystore (success={})", wiped)
 
         val cryptoClient = MlsCryptoClient.create(
-            appId = appId,
+            appId = applicationQualifiedId.id,
             ciphersuiteCode = mlsCipherSuiteCode
         )
         cryptoClient.initializeProteusClient()
@@ -364,15 +363,14 @@ internal suspend fun getOrInitCryptoClient(
 
         val deviceId = clientResponse.id
         val cryptoClientId = CryptoClientId.create(
-            appId = appId,
-            deviceId = deviceId,
-            userDomain = backendDomain
+            applicationQualifiedId = applicationQualifiedId,
+            deviceId = deviceId
         )
         appStorage.saveDeviceId(deviceId = deviceId)
 
         logger.info(
             "Initializing MLS Client for {} on device: {}",
-            appId.obfuscateId(),
+            applicationQualifiedId.id.obfuscateId(),
             deviceId.obfuscateClientId()
         )
         cryptoClient.initializeMlsClient(

--- a/lib/src/main/kotlin/com/wire/sdk/model/CryptoClientId.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/CryptoClientId.kt
@@ -18,7 +18,6 @@ package com.wire.sdk.model
 
 import com.wire.sdk.utils.obfuscateClientId
 import kotlinx.serialization.Serializable
-import java.util.UUID
 
 @JvmInline
 @Serializable
@@ -27,12 +26,11 @@ value class CryptoClientId(val value: String) {
 
     companion object {
         fun create(
-            appId: UUID,
-            deviceId: String,
-            userDomain: String
+            applicationQualifiedId: QualifiedId,
+            deviceId: String
         ): CryptoClientId =
             CryptoClientId(
-                value = "$appId:$deviceId@$userDomain"
+                value = "${applicationQualifiedId.id}:$deviceId@${applicationQualifiedId.domain}"
             )
     }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/model/QualifiedId.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/QualifiedId.kt
@@ -33,4 +33,11 @@ data class QualifiedId(
     override fun toString(): String = "${id.obfuscateId()}@$domain" // Avoid accidental logging
 
     fun toFullString(): String = "$id@$domain"
+
+    companion object {
+        fun fromFullString(value: String): QualifiedId {
+            val (id, domain) = value.split("@", limit = 2)
+            return QualifiedId(id = UUID.fromString(id), domain = domain)
+        }
+    }
 }

--- a/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/model/http/user/SelfUserResponse.kt
@@ -16,6 +16,7 @@
 
 package com.wire.sdk.model.http.user
 
+import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.utils.UUIDSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -23,6 +24,8 @@ import java.util.UUID
 
 @Serializable
 data class SelfUserResponse(
+    @SerialName("qualified_id")
+    val qualifiedId: QualifiedId,
     @Serializable(with = UUIDSerializer::class)
     @SerialName("team")
     val teamId: UUID?

--- a/lib/src/main/kotlin/com/wire/sdk/persistence/AppSqlLiteStorage.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/persistence/AppSqlLiteStorage.kt
@@ -20,15 +20,21 @@ import com.wire.sdk.App
 import com.wire.sdk.AppQueries
 import com.wire.sdk.AppsSdkDatabase
 import com.wire.sdk.config.IsolatedKoinContext
+import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.AppData
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
 import com.wire.sdk.utils.AESDecrypt
 import com.wire.sdk.utils.AESEncrypt
 import java.util.Base64
+import java.util.UUID
 
 private const val DEVICE_ID = "device_id"
 private const val BACKEND_COOKIE = "backend_cookie"
 private const val SHOULD_REJOIN_CONVERSATIONS = "should_rejoin_conversations"
 private const val LAST_NOTIFICATION_ID = "last_notification_id"
+private const val APPLICATION_QUALIFIED_ID = "application_qualified_id"
+private const val APPLICATION_TEAM_ID = "application_team_id"
 
 @Suppress("TooManyFunctions")
 class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
@@ -59,6 +65,46 @@ class AppSqlLiteStorage(db: AppsSdkDatabase) : AppStorage {
     override fun saveDeviceId(deviceId: String) = save(DEVICE_ID, deviceId)
 
     override fun deleteDeviceId() = delete(DEVICE_ID)
+
+    override fun getApplicationQualifiedId(): QualifiedId {
+        val applicationQualifiedId = runCatching {
+            getByKey(APPLICATION_QUALIFIED_ID).value
+        }.getOrNull()
+
+        if (applicationQualifiedId.isNullOrBlank()) {
+            throw WireException.InvalidParameter("No Application QualifiedId found")
+        }
+
+        return QualifiedId.fromFullString(applicationQualifiedId)
+    }
+
+    override fun saveApplicationQualified(applicationQualified: QualifiedId) =
+        save(APPLICATION_QUALIFIED_ID, applicationQualified.toFullString())
+
+    override fun hasApplicationQualifiedId(): Boolean =
+        runCatching {
+            getByKey(APPLICATION_QUALIFIED_ID).value
+        }.getOrNull() != null
+
+    override fun getApplicationTeamId(): TeamId {
+        val applicationTeamId = runCatching {
+            getByKey(APPLICATION_TEAM_ID).value
+        }.getOrNull()
+
+        if (applicationTeamId.isNullOrBlank()) {
+            throw WireException.InvalidParameter("No Application TeamId found")
+        }
+
+        return TeamId(UUID.fromString(applicationTeamId))
+    }
+
+    override fun saveApplicationTeamId(applicationTeamId: TeamId) =
+        save(APPLICATION_TEAM_ID, applicationTeamId.value.toString())
+
+    override fun hasApplicationTeamId(): Boolean =
+        runCatching {
+            getByKey(APPLICATION_TEAM_ID).value
+        }.getOrNull() != null
 
     override fun getBackendCookie(): String? =
         runCatching {

--- a/lib/src/main/kotlin/com/wire/sdk/persistence/AppStorage.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/persistence/AppStorage.kt
@@ -16,6 +16,8 @@
 package com.wire.sdk.persistence
 
 import com.wire.sdk.model.AppData
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
 
 @Suppress("TooManyFunctions")
 interface AppStorage {
@@ -38,6 +40,18 @@ interface AppStorage {
     fun saveDeviceId(deviceId: String)
 
     fun deleteDeviceId()
+
+    fun getApplicationQualifiedId(): QualifiedId
+
+    fun saveApplicationQualified(applicationQualified: QualifiedId)
+
+    fun hasApplicationQualifiedId(): Boolean
+
+    fun getApplicationTeamId(): TeamId
+
+    fun saveApplicationTeamId(applicationTeamId: TeamId)
+
+    fun hasApplicationTeamId(): Boolean
 
     fun getBackendCookie(): String?
 

--- a/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/EventsRouter.kt
@@ -24,7 +24,6 @@ import com.wire.crypto.toWelcome
 import com.wire.sdk.WireEventsHandler
 import com.wire.sdk.WireEventsHandlerDefault
 import com.wire.sdk.WireEventsHandlerSuspending
-import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.ConversationMember
@@ -47,6 +46,7 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.wire.sdk.client.ConversationsApiClient
 import com.wire.sdk.client.MlsApiClient
+import com.wire.sdk.persistence.AppStorage
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineDispatcher
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class EventsRouter internal constructor(
     private val teamStorage: TeamStorage,
+    private val appStorage: AppStorage,
     private val conversationService: ConversationService,
     private val conversationsApiClient: ConversationsApiClient,
     private val mlsApiClient: MlsApiClient,
@@ -73,6 +74,12 @@ internal class EventsRouter internal constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AutoCloseable {
     private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val appQualifiedId: QualifiedId by lazy {
+        appStorage.getApplicationQualifiedId()
+    }
+
+    fun getApplicationQualifiedId(): QualifiedId = appQualifiedId
 
     /**
      * Coroutine scope for running events of different conversation concurrently and
@@ -290,7 +297,7 @@ internal class EventsRouter internal constructor(
             is EventContentDTO.Team.MemberJoin -> {
                 val userId = QualifiedId(
                     id = UUID.fromString(event.data.nonQualifiedUserId),
-                    domain = IsolatedKoinContext.getBackendDomain()
+                    domain = getApplicationQualifiedId().domain
                 )
                 val teamId = TeamId(event.teamId)
                 logger.info("Team member join: teamId={}, userId={}", teamId, userId)

--- a/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/WireApplicationManager.kt
@@ -68,6 +68,28 @@ class WireApplicationManager internal constructor(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
+    private val appQualifiedId: QualifiedId by lazy {
+        appStorage.getApplicationQualifiedId()
+    }
+
+    private val appTeamId: TeamId by lazy {
+        appStorage.getApplicationTeamId()
+    }
+
+    /**
+     * Returns the App QualifiedId
+     * @throws [WireException.InvalidParameter] if called before client initialization
+     */
+    @Throws(WireException.InvalidParameter::class)
+    fun getApplicationQualifiedId(): QualifiedId = appQualifiedId
+
+    /**
+     * Returns the App TeamId
+     * @throws [WireException.InvalidParameter] if called before client initialization
+     */
+    @Throws(WireException.InvalidParameter::class)
+    fun getApplicationTeamId(): TeamId = appTeamId
+
     /**
      * Returns a list of all team IDs that have been registered with this application.
      */

--- a/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/conversation/ConversationService.kt
@@ -25,10 +25,8 @@ import com.wire.sdk.client.BackendClient
 import com.wire.sdk.client.ConversationsApiClient
 import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.client.OneToOneConversationsApiClient
-import com.wire.sdk.client.SelfApiClient
 import com.wire.sdk.client.TeamsApiClient
 import com.wire.sdk.client.UsersApiClient
-import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.crypto.MlsCryptoClient
 import com.wire.sdk.crypto.MlsCryptoClient.Companion.toHexString
@@ -54,19 +52,13 @@ import com.wire.sdk.model.http.conversation.getRemovalKey
 import com.wire.sdk.persistence.AppStorage
 import com.wire.sdk.persistence.ConversationStorage
 import com.wire.sdk.utils.obfuscateId
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import org.slf4j.LoggerFactory
-import java.util.UUID
 import kotlin.io.encoding.Base64
 
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
 internal class ConversationService internal constructor(
     private val backendClient: BackendClient,
     private val usersApiClient: UsersApiClient,
-    private val selfApiClient: SelfApiClient,
     private val conversationsApiClient: ConversationsApiClient,
     private val oneToOneConversationsApiClient: OneToOneConversationsApiClient,
     private val teamsApiClient: TeamsApiClient,
@@ -77,16 +69,17 @@ internal class ConversationService internal constructor(
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    private val selfTeamId: Deferred<UUID?> by lazy {
-        CoroutineScope(Dispatchers.IO).async {
-            selfApiClient.getSelfUser().teamId
-        }
+    private val appQualifiedId: QualifiedId by lazy {
+        appStorage.getApplicationQualifiedId()
     }
 
-    private suspend fun getSelfTeamId(): TeamId =
-        selfTeamId.await()
-            ?.let(::TeamId)
-            ?: throw WireException.MissingParameter("TeamId should not be empty or null.")
+    private val appTeamId: TeamId by lazy {
+        appStorage.getApplicationTeamId()
+    }
+
+    private fun getApplicationQualifiedId(): QualifiedId = appQualifiedId
+
+    private fun getApplicationTeamId(): TeamId = appTeamId
 
     /**
      * Creates a Group Conversation where currently the only admin is the App
@@ -101,11 +94,10 @@ internal class ConversationService internal constructor(
         name: String,
         userIds: List<QualifiedId>
     ): QualifiedId {
-        val teamId = getSelfTeamId()
         val conversationCreatedResponse = conversationsApiClient.createGroupConversation(
             createConversationRequest = CreateConversationRequest.createGroup(
                 name = name,
-                teamId = teamId
+                teamId = getApplicationTeamId()
             )
         )
 
@@ -135,11 +127,10 @@ internal class ConversationService internal constructor(
         userIds: List<QualifiedId>
     ): QualifiedId {
         try {
-            val teamId = getSelfTeamId()
             val conversationCreatedResponse = conversationsApiClient.createGroupConversation(
                 createConversationRequest = CreateConversationRequest.createChannel(
                     name = name,
-                    teamId = teamId
+                    teamId = getApplicationTeamId()
                 )
             )
 
@@ -238,7 +229,7 @@ internal class ConversationService internal constructor(
             externalSenders = publicKeys
         )
 
-        val users = userIds + listOf(IsolatedKoinContext.getApplicationUser())
+        val users = userIds + listOf(getApplicationQualifiedId())
 
         val claimedKeyPackagesResult = claimKeyPackages(
             userIds = users,
@@ -525,13 +516,12 @@ internal class ConversationService internal constructor(
         )
 
         requireAppIsInConversation(conversationId)
-        val appUser = IsolatedKoinContext.getApplicationUser()
-        conversationsApiClient.leaveConversation(appUser, conversationId)
+        conversationsApiClient.leaveConversation(getApplicationQualifiedId(), conversationId)
         deleteAllConversationDataFromLocalStorages(conversationId, conversation.mlsGroupId)
 
         logger.info(
             "App user left the conversation. user: {}, conversationId: {}",
-            appUser,
+            getApplicationQualifiedId(),
             conversationId
         )
     }
@@ -579,7 +569,7 @@ internal class ConversationService internal constructor(
     }
 
     private fun requireAppIsAdminInConversation(conversationId: QualifiedId) {
-        val appUserId = IsolatedKoinContext.getApplicationUser().id
+        val appUserId = getApplicationQualifiedId().id
 
         val isAppAdminInConversation = getStoredConversationMembers(conversationId).any {
             it.userId.id == appUserId && it.role == ConversationRole.ADMIN
@@ -597,7 +587,7 @@ internal class ConversationService internal constructor(
     }
 
     private fun requireAppIsInConversation(conversationId: QualifiedId) {
-        val appUserId = IsolatedKoinContext.getApplicationUser().id
+        val appUserId = getApplicationQualifiedId().id
         val isAppInConversation = getStoredConversationMembers(conversationId).any {
             it.userId.id == appUserId
         }
@@ -631,7 +621,7 @@ internal class ConversationService internal constructor(
         conversationId: QualifiedId,
         users: List<QualifiedId>
     ) {
-        val appUser = IsolatedKoinContext.getApplicationUser()
+        val appUser = getApplicationQualifiedId()
 
         if (appUser in users) {
             conversationStorage.getById(conversationId = conversationId)?.let {
@@ -811,9 +801,8 @@ internal class ConversationService internal constructor(
             logger.debug("Mapping {} clients for User: {}", clients.size, user.id)
             clients.map { client ->
                 CryptoClientId.create(
-                    appId = user.id,
-                    deviceId = client.id,
-                    userDomain = user.domain
+                    applicationQualifiedId = user,
+                    deviceId = client.id
                 )
             }
         }.also {

--- a/lib/src/main/kotlin/com/wire/sdk/service/self/SelfService.kt
+++ b/lib/src/main/kotlin/com/wire/sdk/service/self/SelfService.kt
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.service.self
+
+import com.wire.sdk.client.SelfApiClient
+import com.wire.sdk.exception.WireException
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
+import com.wire.sdk.persistence.AppStorage
+import java.util.UUID
+import org.slf4j.LoggerFactory
+
+/**
+ * Service layer responsible for fetching self user (App user) data from the backend, mapping and
+ * saving them locally.
+ */
+internal class SelfService(
+    private val selfApiClient: SelfApiClient,
+    private val appStorage: AppStorage
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun fetchAndSaveApplicationData() {
+        this.logger.info("Fetching application QualifiedId")
+        val applicationData = selfApiClient.getSelfUser()
+
+        saveApplicationQualified(applicationData.qualifiedId)
+        saveApplicationTeamId(applicationData.teamId)
+    }
+
+    private fun saveApplicationQualified(applicationQualifiedId: QualifiedId) {
+        if (!appStorage.hasApplicationQualifiedId()) {
+            this.logger.info("Saving application QualifiedId: $applicationQualifiedId")
+            appStorage.saveApplicationQualified(applicationQualifiedId)
+            return
+        }
+
+        val storedApplicationQualifiedId = appStorage.getApplicationQualifiedId()
+        if (storedApplicationQualifiedId.toFullString() != applicationQualifiedId.toFullString()) {
+            throw WireException.UnknownError(
+                """
+                    Stored application QualifiedId $storedApplicationQualifiedId does not match fetched self QualifiedId $applicationQualifiedId. Clear SDK storage before using a token for another app.
+                """.trimIndent()
+            )
+        }
+
+        this.logger.info("Application QualifiedId already stored: $storedApplicationQualifiedId")
+    }
+
+    private fun saveApplicationTeamId(teamId: UUID?) {
+        teamId ?: throw WireException.InvalidParameter("The application does not belong to a team")
+
+        val applicationTeamId = TeamId(teamId)
+        if (!appStorage.hasApplicationTeamId()) {
+            this.logger.info("Saving application TeamId: $applicationTeamId")
+            appStorage.saveApplicationTeamId(applicationTeamId)
+            return
+        }
+
+        val storedApplicationTeamId = appStorage.getApplicationTeamId()
+        if (storedApplicationTeamId.value.toString() != applicationTeamId.value.toString()) {
+            throw WireException.UnknownError(
+                """
+                    Stored application TeamId $storedApplicationTeamId does not match fetched self TeamId $applicationTeamId. Clear SDK storage before using a token for another app.
+                """.trimIndent()
+            )
+        }
+
+        this.logger.info("Application TeamId already stored: $storedApplicationTeamId")
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
@@ -189,7 +189,6 @@ object TestUtils {
 
     fun setupSdk(eventsHandler: WireEventsHandler) {
         WireAppSdk(
-            applicationId = APPLICATION_ID,
             apiToken = API_TOKEN,
             apiHost = API_HOST,
             cryptographyStorageKey = CRYPTOGRAPHY_STORAGE_KEY,
@@ -205,7 +204,6 @@ object TestUtils {
         return ConversationMemberSelf(qualifiedId, conversationRole)
     }
 
-    val APPLICATION_ID = UUID.randomUUID()
     private const val API_TOKEN = "dummyToken"
     private const val API_HOST = "http://localhost:8086"
     val CRYPTOGRAPHY_STORAGE_KEY = "myDummyPasswordOfRandom32BytesCH".toByteArray()

--- a/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/TestUtils.kt
@@ -22,12 +22,18 @@ import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
 import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.http.conversation.ConversationMemberSelf
 import com.wire.sdk.model.http.conversation.ConversationRole
 import java.util.UUID
 
 object TestUtils {
     const val TEST_API_VERSION = "v15"
+    val APPLICATION_QUALIFIED_ID = QualifiedId(
+        id = UUID.fromString("b82c3381-37b0-4545-b555-ca32a3a093d0"),
+        domain = "staging.zinfra.io"
+    )
+    val APPLICATION_TEAM_ID = TeamId(UUID.fromString("86fdb92f-76b8-4548-8f21-6e3fd3f5f449"))
 
     fun setupWireMockStubs(wireMockServer: WireMockServer) {
         wireMockServer.stubFor(
@@ -174,10 +180,10 @@ object TestUtils {
                     """
                         {
                           "qualified_id": {
-                            "domain": "staging.zinfra.io",
-                            "id": "b82c3381-37b0-4545-b555-ca32a3a093d0"
+                            "domain": "${APPLICATION_QUALIFIED_ID.domain}",
+                            "id": "${APPLICATION_QUALIFIED_ID.id}"
                           },
-                          "team": "86fdb92f-76b8-4548-8f21-6e3fd3f5f449",
+                          "team": "${APPLICATION_TEAM_ID.value}",
                           "email": "sdk.user@wire.com",
                           "name": "SDK User"
                         }

--- a/lib/src/test/kotlin/com/wire/sdk/WireAppSdkTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/WireAppSdkTest.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
-import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
@@ -42,7 +41,6 @@ class WireAppSdkTest {
         TestUtils.setupWireMockStubs(wireMockServer = wireMockServer)
         val wireAppSdk =
             WireAppSdk(
-                applicationId = APPLICATION_ID,
                 apiToken = API_TOKEN,
                 apiHost = API_HOST,
                 cryptographyStorageKey = TestUtils.CRYPTOGRAPHY_STORAGE_KEY,
@@ -77,7 +75,6 @@ class WireAppSdkTest {
 
         val wireAppSdk =
             WireAppSdk(
-                applicationId = APPLICATION_ID,
                 apiToken = API_TOKEN,
                 apiHost = API_HOST,
                 cryptographyStorageKey = TestUtils.CRYPTOGRAPHY_STORAGE_KEY,
@@ -98,7 +95,6 @@ class WireAppSdkTest {
 
             // Create the SDK instance
             val wireAppSdk = WireAppSdk(
-                applicationId = APPLICATION_ID,
                 apiToken = API_TOKEN,
                 apiHost = API_HOST,
                 cryptographyStorageKey = TestUtils.CRYPTOGRAPHY_STORAGE_KEY,
@@ -148,7 +144,6 @@ class WireAppSdkTest {
         }
 
     companion object {
-        private val APPLICATION_ID = UUID.randomUUID()
         private const val API_TOKEN = "dummyToken"
         private const val API_HOST = "http://localhost:8086"
 

--- a/lib/src/test/kotlin/com/wire/sdk/client/ClientsApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/ClientsApiClientTest.kt
@@ -17,6 +17,7 @@
 package com.wire.sdk.client
 
 import com.wire.sdk.model.CryptoClientId
+import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.persistence.AppStorage
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -71,9 +72,11 @@ class ClientsApiClientTest {
 
             api.updateClientWithMlsPublicKey(
                 CryptoClientId.create(
-                    UUID.randomUUID(),
-                    UUID.randomUUID().toString(),
-                    "example.com"
+                    applicationQualifiedId = QualifiedId(
+                        id = UUID.randomUUID(),
+                        domain = "example.com"
+                    ),
+                    deviceId = UUID.randomUUID().toString()
                 ),
                 com.wire.sdk.model.http.MlsPublicKeys()
             )

--- a/lib/src/test/kotlin/com/wire/sdk/client/SelfApiClientTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/client/SelfApiClientTest.kt
@@ -53,6 +53,13 @@ class SelfApiClientTest {
         }
 
     @Test
+    fun `given qualifiedId in response, when getSelfUser, then qualifiedId deserialized`() =
+        runTest {
+            val result = apiClient(SELF_RESPONSE_WITH_TEAM).getSelfUser()
+            assertEquals(SELF_QUALIFIED_ID, result.qualifiedId)
+        }
+
+    @Test
     fun `given null teamId in response, when getSelfUser, then teamId is null`() =
         runTest {
             val result = apiClient(SELF_RESPONSE_NO_TEAM).getSelfUser()
@@ -61,7 +68,29 @@ class SelfApiClientTest {
 
     companion object {
         private val TEAM_ID = UUID.randomUUID()
-        private val SELF_RESPONSE_WITH_TEAM = """{ "team": "$TEAM_ID" }"""
-        private val SELF_RESPONSE_NO_TEAM = """{ "team": null }"""
+        private val SELF_QUALIFIED_ID = com.wire.sdk.model.QualifiedId(
+            id = UUID.randomUUID(),
+            domain = "wire.example.com"
+        )
+        private val SELF_RESPONSE_WITH_TEAM =
+            """
+                {
+                    "qualified_id": {
+                        "id": "${SELF_QUALIFIED_ID.id}",
+                        "domain": "${SELF_QUALIFIED_ID.domain}"
+                    },
+                    "team": "$TEAM_ID"
+                }
+            """.trimIndent()
+        private val SELF_RESPONSE_NO_TEAM =
+            """
+                {
+                    "qualified_id": {
+                        "id": "${SELF_QUALIFIED_ID.id}",
+                        "domain": "${SELF_QUALIFIED_ID.domain}"
+                    },
+                    "team": null
+                }
+            """.trimIndent()
     }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/config/IsolatedKoinContextTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/config/IsolatedKoinContextTest.kt
@@ -15,22 +15,14 @@
 
 package com.wire.sdk.config
 
-import com.wire.sdk.model.QualifiedId
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotSame
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.UUID
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 class IsolatedKoinContextTest {
     @BeforeEach
@@ -67,104 +59,6 @@ class IsolatedKoinContextTest {
         IsolatedKoinContext.start()
         val secondApp = IsolatedKoinContext.koinApp
         assertNotSame(firstApp, secondApp)
-    }
-
-    @Test
-    fun `stop clears applicationUser cache`() {
-        val id = UUID.randomUUID()
-        IsolatedKoinContext.setApplicationId(id)
-        IsolatedKoinContext.setBackendDomain("wire.example.com")
-        IsolatedKoinContext.getApplicationUser() // populate cache
-
-        IsolatedKoinContext.stop()
-        IsolatedKoinContext.start()
-
-        // After a fresh start the cached user must be gone
-        assertThrows<IllegalStateException> {
-            IsolatedKoinContext.getApplicationUser()
-        }
-    }
-
-    @Test
-    fun `getApplicationUser returns correct QualifiedId when both properties are set`() {
-        val id = UUID.randomUUID()
-        val domain = "wire.example.com"
-
-        IsolatedKoinContext.setApplicationId(id)
-        IsolatedKoinContext.setBackendDomain(domain)
-
-        val user: QualifiedId = IsolatedKoinContext.getApplicationUser()
-
-        assertEquals(id, user.id)
-        assertEquals(domain, user.domain)
-    }
-
-    @Test
-    fun `getApplicationUser throws when applicationId is not set`() {
-        IsolatedKoinContext.setBackendDomain("wire.example.com")
-
-        assertThrows<IllegalStateException> {
-            IsolatedKoinContext.getApplicationUser()
-        }
-    }
-
-    @Test
-    fun `getApplicationUser throws when backendDomain is not set`() {
-        IsolatedKoinContext.setApplicationId(UUID.randomUUID())
-
-        assertThrows<IllegalStateException> {
-            IsolatedKoinContext.getApplicationUser()
-        }
-    }
-
-    @Test
-    fun `getApplicationUser throws when neither applicationId nor backendDomain are set`() {
-        assertThrows<IllegalStateException> {
-            IsolatedKoinContext.getApplicationUser()
-        }
-    }
-
-    @Test
-    fun `getApplicationUser returns cached instance on repeated calls`() {
-        IsolatedKoinContext.setApplicationId(UUID.randomUUID())
-        IsolatedKoinContext.setBackendDomain("wire.example.com")
-
-        val first = IsolatedKoinContext.getApplicationUser()
-        val second = IsolatedKoinContext.getApplicationUser()
-
-        assertSame(first, second)
-    }
-
-    @Test
-    fun `setApplicationId clears cached applicationUser`() {
-        val id1 = UUID.randomUUID()
-        val id2 = UUID.randomUUID()
-        val domain = "wire.example.com"
-
-        IsolatedKoinContext.setApplicationId(id1)
-        IsolatedKoinContext.setBackendDomain(domain)
-        val firstUser = IsolatedKoinContext.getApplicationUser()
-        assertEquals(id1, firstUser.id)
-
-        IsolatedKoinContext.setApplicationId(id2)
-        val secondUser = IsolatedKoinContext.getApplicationUser()
-        assertEquals(id2, secondUser.id)
-        assertNotEquals(firstUser, secondUser)
-    }
-
-    @Test
-    fun `setBackendDomain clears cached applicationUser`() {
-        val id = UUID.randomUUID()
-
-        IsolatedKoinContext.setApplicationId(id)
-        IsolatedKoinContext.setBackendDomain("first.example.com")
-        val firstUser = IsolatedKoinContext.getApplicationUser()
-        assertEquals("first.example.com", firstUser.domain)
-
-        IsolatedKoinContext.setBackendDomain("second.example.com")
-        val secondUser = IsolatedKoinContext.getApplicationUser()
-        assertEquals("second.example.com", secondUser.domain)
-        assertNotEquals(firstUser, secondUser)
     }
 
     @Test
@@ -216,58 +110,5 @@ class IsolatedKoinContextTest {
         val key = ByteArray(0)
         IsolatedKoinContext.setCryptographyStorageKey(key)
         assertArrayEquals(key, IsolatedKoinContext.getCryptographyStorageKey())
-    }
-
-    @Test
-    fun `getApplicationUser is safe under concurrent access`() {
-        val id = UUID.randomUUID()
-        val domain = "wire.example.com"
-        IsolatedKoinContext.setApplicationId(id)
-        IsolatedKoinContext.setBackendDomain(domain)
-
-        val threadCount = 20
-        val latch = CountDownLatch(threadCount)
-        val executor = Executors.newFixedThreadPool(threadCount)
-        val results = mutableListOf<QualifiedId>()
-        val lock = Any()
-
-        repeat(threadCount) {
-            executor.submit {
-                try {
-                    val user = IsolatedKoinContext.getApplicationUser()
-                    synchronized(lock) { results.add(user) }
-                } finally {
-                    latch.countDown()
-                }
-            }
-        }
-
-        assertTrue(latch.await(5, TimeUnit.SECONDS))
-        executor.shutdown()
-
-        assertEquals(threadCount, results.size)
-        val first = results.first()
-        results.forEach { assertSame(first, it) }
-    }
-
-    @Test
-    fun `getApplicationUser reflects latest applicationId after cache is cleared`() {
-        val initialId = UUID.randomUUID()
-        val updatedId = UUID.randomUUID()
-        val domain = "wire.example.com"
-
-        IsolatedKoinContext.setApplicationId(initialId)
-        IsolatedKoinContext.setBackendDomain(domain)
-        IsolatedKoinContext.getApplicationUser() // populate cache
-
-        IsolatedKoinContext.setApplicationId(updatedId) // clears cache, updates Koin
-
-        val user = IsolatedKoinContext.getApplicationUser()
-        assertEquals(
-            updatedId,
-            user.id,
-            "User must reflect the updated applicationId, not the cached stale one"
-        )
-        assertEquals(domain, user.domain)
     }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/model/CryptoClientIdTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/CryptoClientIdTest.kt
@@ -2,6 +2,7 @@ package com.wire.sdk.model
 
 import com.wire.sdk.utils.KtxSerializer
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.UUID
 import kotlin.test.Test
 
 class CryptoClientIdTest {
@@ -12,5 +13,19 @@ class CryptoClientIdTest {
         val deserializedCryptoClientId = KtxSerializer.json.decodeFromString<CryptoClientId>(json)
 
         assertEquals(cryptoClientId, deserializedCryptoClientId)
+    }
+
+    @Test
+    fun `create builds client id from qualified id and device id`() {
+        val appId = UUID.randomUUID()
+        val qualifiedId = QualifiedId(appId, "wire.example.com")
+        val deviceId = "device-123"
+
+        val cryptoClientId = CryptoClientId.create(
+            applicationQualifiedId = qualifiedId,
+            deviceId = deviceId
+        )
+
+        assertEquals("$appId:$deviceId@wire.example.com", cryptoClientId.value)
     }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/model/QualifiedIdTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/model/QualifiedIdTest.kt
@@ -89,6 +89,13 @@ class QualifiedIdTest {
         assertEquals("$uuid1@$domainA", result)
     }
 
+    @Test
+    fun `fromFullString should parse full id and domain`() {
+        val result = QualifiedId.fromFullString("$uuid1@$domainA")
+
+        assertEquals(QualifiedId(uuid1, domainA), result)
+    }
+
     // --- Serialization ---
 
     @Test

--- a/lib/src/test/kotlin/com/wire/sdk/persistence/AppSqlLiteStorageTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/persistence/AppSqlLiteStorageTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -43,6 +44,23 @@ class AppSqlLiteStorageTest {
             appStorage.saveBackendCookie(cookie)
             val secondCookie = appStorage.getBackendCookie()
             assertTrue { secondCookie == cookie }
+        }
+
+    @Test
+    fun givenApplicationData_thenQualifiedIdAndTeamIdArePersisted() =
+        runTest {
+            val eventsHandler = object : WireEventsHandlerSuspending() {}
+            TestUtils.setupSdk(eventsHandler)
+
+            val appStorage = IsolatedKoinContext.koinApp.koin.get<AppStorage>()
+
+            appStorage.saveApplicationQualified(TestUtils.APPLICATION_QUALIFIED_ID)
+            appStorage.saveApplicationTeamId(TestUtils.APPLICATION_TEAM_ID)
+
+            assertTrue(appStorage.hasApplicationQualifiedId())
+            assertTrue(appStorage.hasApplicationTeamId())
+            assertEquals(TestUtils.APPLICATION_QUALIFIED_ID, appStorage.getApplicationQualifiedId())
+            assertEquals(TestUtils.APPLICATION_TEAM_ID, appStorage.getApplicationTeamId())
         }
 
     companion object {

--- a/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/EventsRouterConcurrencyTest.kt
@@ -17,6 +17,7 @@
 package com.wire.sdk.service
 
 import com.wire.crypto.ConversationId
+import com.wire.sdk.TestUtils
 import com.wire.sdk.WireEventsHandler
 import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.client.ConversationsApiClient
@@ -26,17 +27,20 @@ import com.wire.sdk.crypto.DecryptedMlsMessage
 import com.wire.sdk.model.ConversationMember
 import com.wire.sdk.model.ConversationEntity
 import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
 import com.wire.sdk.model.WireMessage
 import com.wire.sdk.model.http.EventContentDTO
 import com.wire.sdk.model.http.EventResponse
 import com.wire.sdk.model.http.conversation.ConversationRole
 import com.wire.sdk.model.http.conversation.Member
 import com.wire.sdk.model.http.conversation.MemberJoinEventData
+import com.wire.sdk.persistence.AppStorage
 import com.wire.sdk.persistence.TeamStorage
 import com.wire.sdk.service.conversation.ConversationService
 import com.wire.sdk.utils.MockCoreCryptoClient
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -46,6 +50,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.util.Collections
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -60,6 +66,50 @@ import kotlin.time.Clock
  * - Channel isolation prevents cross-conversation failures
  */
 class EventsRouterConcurrencyTest {
+    @Test
+    fun `given team member join event, when routed, then qualify user with app domain`() =
+        runTest {
+            val joinedUserId = UUID.randomUUID()
+            val teamId = UUID.randomUUID()
+            var capturedUserId: QualifiedId? = null
+            var capturedTeamId: TeamId? = null
+            val latch = CountDownLatch(1)
+            val handler = object : WireEventsHandlerSuspending() {
+                override suspend fun onTeamMemberJoined(
+                    userId: QualifiedId,
+                    teamId: TeamId
+                ) {
+                    capturedUserId = userId
+                    capturedTeamId = teamId
+                    latch.countDown()
+                }
+            }
+            val router = createEventsRouter(wireEventsHandler = handler)
+
+            router.route(
+                EventResponse(
+                    id = UUID.randomUUID().toString(),
+                    payload = listOf(
+                        EventContentDTO.Team.MemberJoin(
+                            teamId = teamId,
+                            time = Clock.System.now(),
+                            data = EventContentDTO.TeamMemberIdData(
+                                nonQualifiedUserId = joinedUserId.toString()
+                            )
+                        )
+                    ),
+                    transient = true
+                )
+            )
+
+            assertTrue(latch.await(1, TimeUnit.SECONDS))
+            assertEquals(
+                QualifiedId(joinedUserId, TestUtils.APPLICATION_QUALIFIED_ID.domain),
+                capturedUserId
+            )
+            assertEquals(TeamId(teamId), capturedTeamId)
+        }
+
     @Test
     fun `MLS message sender comes from decrypted sender client ID`() =
         runTest {
@@ -521,6 +571,9 @@ class EventsRouterConcurrencyTest {
 
     private fun createEventsRouter(
         teamStorage: TeamStorage = mockk(relaxed = true),
+        appStorage: AppStorage = mockk {
+            every { getApplicationQualifiedId() } returns TestUtils.APPLICATION_QUALIFIED_ID
+        },
         conversationService: ConversationService = mockk(relaxed = true),
         conversationsApiClient: ConversationsApiClient = mockk(relaxed = true),
         mlsApiClient: MlsApiClient = mockk(relaxed = true),
@@ -532,6 +585,7 @@ class EventsRouterConcurrencyTest {
 
         return EventsRouter(
             teamStorage = teamStorage,
+            appStorage = appStorage,
             conversationService = conversationService,
             conversationsApiClient = conversationsApiClient,
             mlsApiClient = mlsApiClient,

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireApplicationManagerTest.kt
@@ -54,12 +54,53 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.koin.core.error.InstanceCreationException
 import java.util.UUID
 import kotlin.io.encoding.Base64
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class WireApplicationManagerTest {
+    @Test
+    fun whenGettingApplicationQualifiedIdThenReturnStoredValue() {
+        val appStorage = mockk<AppStorage> {
+            every { getApplicationQualifiedId() } returns TestUtils.APPLICATION_QUALIFIED_ID
+        }
+        val manager = WireApplicationManager(
+            teamStorage = mockk(),
+            backendClient = mockk(),
+            userService = mockk(),
+            mlsApiClient = mockk(),
+            assetsApiClient = mockk(),
+            cryptoClient = mockk(),
+            mlsFallbackStrategy = mockk(),
+            conversationService = mockk(),
+            appStorage = appStorage
+        )
+
+        assertEquals(TestUtils.APPLICATION_QUALIFIED_ID, manager.getApplicationQualifiedId())
+    }
+
+    @Test
+    fun whenGettingApplicationTeamIdThenReturnStoredValue() {
+        val appStorage = mockk<AppStorage> {
+            every { getApplicationTeamId() } returns TestUtils.APPLICATION_TEAM_ID
+        }
+        val manager = WireApplicationManager(
+            teamStorage = mockk(),
+            backendClient = mockk(),
+            userService = mockk(),
+            mlsApiClient = mockk(),
+            assetsApiClient = mockk(),
+            cryptoClient = mockk(),
+            mlsFallbackStrategy = mockk(),
+            conversationService = mockk(),
+            appStorage = appStorage
+        )
+
+        assertEquals(TestUtils.APPLICATION_TEAM_ID, manager.getApplicationTeamId())
+    }
+
     @Test
     fun whenCreatingGroupConversationSuccessfullyThenReturnsConversationIdAndUpdateMemberRole() =
         runTest {
@@ -311,19 +352,11 @@ class WireApplicationManagerTest {
                 )
             )
 
-            val manager = IsolatedKoinContext.koinApp.koin.get<WireApplicationManager>()
-
             // then
-            assertThrows<WireException.MissingParameter> {
-                // when
-                manager.createChannelConversation(
-                    name = CONVERSATION_NAME,
-                    userIds = listOf(
-                        USER_1,
-                        USER_2
-                    )
-                )
+            val exception = assertThrows<InstanceCreationException> {
+                IsolatedKoinContext.koinApp.koin.get<WireApplicationManager>()
             }
+            assertTrue(exception.hasCause<WireException.InvalidParameter>())
         }
 
     @Test
@@ -890,6 +923,9 @@ class WireApplicationManagerTest {
             )
             cryptoClientUser2.mlsGenerateKeyPackages(10U)
         }
+
+    private inline fun <reified T : Throwable> Throwable.hasCause(): Boolean =
+        generateSequence(this) { it.cause }.any { it is T }
 
     companion object {
         private const val DEVICE_ID = "device-id-123"

--- a/lib/src/test/kotlin/com/wire/sdk/service/WireEventsIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/WireEventsIntegrationTest.kt
@@ -37,6 +37,7 @@ import com.wire.sdk.model.http.conversation.ConversationRole
 import com.wire.sdk.model.http.conversation.Member
 import com.wire.sdk.model.http.conversation.MemberJoinEventData
 import com.wire.sdk.model.http.conversation.MemberLeaveEventData
+import com.wire.sdk.persistence.AppStorage
 import com.wire.sdk.persistence.ConversationStorage
 import com.wire.sdk.utils.MockCoreCryptoClient
 import kotlinx.coroutines.delay
@@ -112,6 +113,9 @@ class WireEventsIntegrationTest {
 
             // Create SDK with our custom handler
             TestUtils.setupSdk(customHandler)
+            val appStorage = IsolatedKoinContext.koinApp.koin.get<AppStorage>()
+            appStorage.saveApplicationQualified(TestUtils.APPLICATION_QUALIFIED_ID)
+            appStorage.saveApplicationTeamId(TEAM_ID)
 
             // Load Koin Modules
             val mockCoreCryptoClient = MockCoreCryptoClient.create(
@@ -240,10 +244,7 @@ class WireEventsIntegrationTest {
                                 time = EXPECTED_NEW_CONVERSATION_VALUE,
                                 data = MemberLeaveEventData(
                                     users = listOf(
-                                        QualifiedId(
-                                            id = TestUtils.APPLICATION_ID,
-                                            domain = "staging.zinfra.io"
-                                        )
+                                        TestUtils.APPLICATION_QUALIFIED_ID
                                     ),
                                     reason = "deletion"
                                 )

--- a/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/conversation/ConversationServiceTest.kt
@@ -25,7 +25,6 @@ import com.wire.sdk.client.MlsApiClient
 import com.wire.sdk.client.OneToOneConversationsApiClient
 import com.wire.sdk.client.TeamsApiClient
 import com.wire.sdk.client.UsersApiClient
-import com.wire.sdk.config.IsolatedKoinContext
 import com.wire.sdk.crypto.CryptoClient
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.ConversationEntity
@@ -55,7 +54,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.verify
 import java.util.UUID
@@ -71,6 +69,8 @@ class ConversationServiceTest {
     fun whenEstablishingConversationsAndShouldRejoinConversationIsFalseThenSkip() =
         runTest {
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 coEvery { getShouldRejoinConversations() } returns false
             }
             val backendClient = mockk<BackendClient>()
@@ -79,7 +79,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -103,6 +102,8 @@ class ConversationServiceTest {
     fun whenEstablishingConversationsAndConversationsAreEmptyThenSkipAndMarkAsRejoined() =
         runTest {
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 every { getShouldRejoinConversations() } returns true
                 every { setShouldRejoinConversations(any()) } returns Unit
             }
@@ -115,7 +116,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -142,6 +142,8 @@ class ConversationServiceTest {
     fun whenEstablishingConversationsAndConversationsExistsLocallyThenSkip() =
         runTest {
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 every { getShouldRejoinConversations() } returns true
                 every { setShouldRejoinConversations(any()) } returns Unit
             }
@@ -164,7 +166,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -194,6 +195,8 @@ class ConversationServiceTest {
     fun whenEstablishingConversationsAndConversationsDoesNotExistsLocallyThenRejoin() =
         runTest {
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 every { getShouldRejoinConversations() } returns true
                 every { setShouldRejoinConversations(any()) } returns Unit
             }
@@ -224,7 +227,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -290,13 +292,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -353,13 +354,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -395,13 +395,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -451,13 +450,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = teamsApiClient,
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -506,13 +504,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = teamsApiClient,
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -561,13 +558,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = teamsApiClient,
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -617,13 +613,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = teamsApiClient,
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -686,13 +681,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -718,13 +712,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = mockk(),
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -751,13 +744,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -799,13 +791,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -844,13 +835,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -904,13 +894,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -993,13 +982,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1054,13 +1042,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = usersApiClient,
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1120,13 +1107,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = usersApiClient,
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1150,13 +1136,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = mockk(),
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -1183,13 +1168,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -1231,13 +1215,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = mockk()
             )
 
@@ -1285,13 +1268,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = usersApiClient,
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1307,9 +1289,8 @@ class ConversationServiceTest {
                     mlsGroupId = CONVERSATION_MLS_GROUP_ID,
                     clientIds = listOf(client1).map { client ->
                         CryptoClientId.create(
-                            appId = CONVERSATION_MEMBER_1.id,
-                            deviceId = client.id,
-                            userDomain = BACKEND_DOMAIN
+                            applicationQualifiedId = CONVERSATION_MEMBER_1,
+                            deviceId = client.id
                         )
                     }
                 )
@@ -1369,13 +1350,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = usersApiClient,
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1389,9 +1369,8 @@ class ConversationServiceTest {
                     mlsGroupId = CONVERSATION_MLS_GROUP_ID,
                     clientIds = listOf(client1, client2, client3).map { client ->
                         CryptoClientId.create(
-                            appId = CONVERSATION_MEMBER_1.id,
-                            deviceId = client.id,
-                            userDomain = BACKEND_DOMAIN
+                            applicationQualifiedId = CONVERSATION_MEMBER_1,
+                            deviceId = client.id
                         )
                     }
                 )
@@ -1437,13 +1416,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = oneToOneConversationsApiClient,
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1481,13 +1459,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = oneToOneConversationsApiClient,
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1540,13 +1517,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = oneToOneConversationsApiClient,
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1591,13 +1567,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = backendClient,
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = oneToOneConversationsApiClient,
                 teamsApiClient = mockk(),
                 mlsApiClient = mlsApiClient,
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1612,6 +1587,8 @@ class ConversationServiceTest {
     fun whenEstablishingConversationsAndGroupConversationIsRejoinedThenSaveToDb() =
         runTest {
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 every { getShouldRejoinConversations() } returns true
                 every { setShouldRejoinConversations(any()) } returns Unit
             }
@@ -1640,7 +1617,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -1669,6 +1645,8 @@ class ConversationServiceTest {
                 type = ConversationResponse.Type.SELF
             )
             val appStorage = mockk<AppStorage> {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
                 every { getShouldRejoinConversations() } returns true
                 every { setShouldRejoinConversations(any()) } returns Unit
             }
@@ -1690,7 +1668,6 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = conversationsApiClient,
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
@@ -1739,13 +1716,12 @@ class ConversationServiceTest {
         val service = ConversationService(
             backendClient = backendClient,
             usersApiClient = usersApiClient,
-            selfApiClient = mockk(),
             conversationsApiClient = mockk(),
             oneToOneConversationsApiClient = mockk(),
             teamsApiClient = mockk(),
             mlsApiClient = mockk(),
             conversationStorage = conversationStorage,
-            appStorage = mockk(),
+            appStorage = appStorageWithApplicationData(),
             cryptoClient = mockk()
         )
 
@@ -1786,13 +1762,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1833,13 +1808,12 @@ class ConversationServiceTest {
             val service = ConversationService(
                 backendClient = mockk(),
                 usersApiClient = mockk(),
-                selfApiClient = mockk(),
                 conversationsApiClient = mockk(),
                 oneToOneConversationsApiClient = mockk(),
                 teamsApiClient = mockk(),
                 mlsApiClient = mockk(),
                 conversationStorage = conversationStorage,
-                appStorage = mockk(),
+                appStorage = appStorageWithApplicationData(),
                 cryptoClient = cryptoClient
             )
 
@@ -1919,8 +1893,15 @@ class ConversationServiceTest {
         )
 
         val APP_USER_ID: UUID = UUID.randomUUID()
+        val APP_QUALIFIED_ID = QualifiedId(APP_USER_ID, BACKEND_DOMAIN)
         val CONVERSATION_MEMBER_1 = QualifiedId(UUID.randomUUID(), BACKEND_DOMAIN)
         val CONVERSATION_MEMBER_2 = QualifiedId(UUID.randomUUID(), BACKEND_DOMAIN)
+
+        fun appStorageWithApplicationData(): AppStorage =
+            mockk {
+                every { getApplicationQualifiedId() } returns APP_QUALIFIED_ID
+                every { getApplicationTeamId() } returns TEAM_ID
+            }
 
         fun createDummyKeyPackage(userId: QualifiedId): KeyPackage =
             KeyPackage(
@@ -1933,10 +1914,6 @@ class ConversationServiceTest {
 
         @JvmStatic
         @BeforeAll
-        fun setUp() {
-            mockkObject(IsolatedKoinContext)
-            every { IsolatedKoinContext.getApplicationUser() } returns
-                QualifiedId(APP_USER_ID, BACKEND_DOMAIN)
-        }
+        fun setUp() = Unit
     }
 }

--- a/lib/src/test/kotlin/com/wire/sdk/service/self/SelfServiceTest.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/service/self/SelfServiceTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.sdk.service.self
+
+import com.wire.sdk.client.SelfApiClient
+import com.wire.sdk.exception.WireException
+import com.wire.sdk.model.QualifiedId
+import com.wire.sdk.model.TeamId
+import com.wire.sdk.model.http.user.SelfUserResponse
+import com.wire.sdk.persistence.AppStorage
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+
+class SelfServiceTest {
+    @Test
+    fun `given application data is not stored, when fetchAndSaveApplicationData, then save it`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { hasApplicationQualifiedId() } returns false
+                every { saveApplicationQualified(APPLICATION_QUALIFIED_ID) } returns Unit
+                every { hasApplicationTeamId() } returns false
+                every { saveApplicationTeamId(APPLICATION_TEAM_ID) } returns Unit
+            }
+            val service = SelfService(selfApiClient(), appStorage)
+
+            service.fetchAndSaveApplicationData()
+
+            verify(exactly = 1) {
+                appStorage.saveApplicationQualified(APPLICATION_QUALIFIED_ID)
+                appStorage.saveApplicationTeamId(APPLICATION_TEAM_ID)
+            }
+        }
+
+    @Test
+    fun `given matching application data is stored, when fetching, then keep it`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { hasApplicationQualifiedId() } returns true
+                every { getApplicationQualifiedId() } returns APPLICATION_QUALIFIED_ID
+                every { hasApplicationTeamId() } returns true
+                every { getApplicationTeamId() } returns APPLICATION_TEAM_ID
+            }
+            val service = SelfService(selfApiClient(), appStorage)
+
+            service.fetchAndSaveApplicationData()
+
+            verify(exactly = 0) {
+                appStorage.saveApplicationQualified(any())
+                appStorage.saveApplicationTeamId(any())
+            }
+        }
+
+    @Test
+    fun `given different qualified id is stored, when fetchAndSaveApplicationData, then throw`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { hasApplicationQualifiedId() } returns true
+                every { getApplicationQualifiedId() } returns QualifiedId(
+                    id = UUID.randomUUID(),
+                    domain = APPLICATION_QUALIFIED_ID.domain
+                )
+            }
+            val service = SelfService(selfApiClient(), appStorage)
+
+            assertFailsWith<WireException.UnknownError> {
+                service.fetchAndSaveApplicationData()
+            }
+        }
+
+    @Test
+    fun `given different team id is stored, when fetchAndSaveApplicationData, then throw`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { hasApplicationQualifiedId() } returns true
+                every { getApplicationQualifiedId() } returns APPLICATION_QUALIFIED_ID
+                every { hasApplicationTeamId() } returns true
+                every { getApplicationTeamId() } returns TeamId(UUID.randomUUID())
+            }
+            val service = SelfService(selfApiClient(), appStorage)
+
+            assertFailsWith<WireException.UnknownError> {
+                service.fetchAndSaveApplicationData()
+            }
+        }
+
+    @Test
+    fun `given self response has no team, when fetchAndSaveApplicationData, then throw`() =
+        runTest {
+            val appStorage = mockk<AppStorage> {
+                every { hasApplicationQualifiedId() } returns true
+                every { getApplicationQualifiedId() } returns APPLICATION_QUALIFIED_ID
+            }
+            val service = SelfService(selfApiClient(teamId = null), appStorage)
+
+            assertFailsWith<WireException.InvalidParameter> {
+                service.fetchAndSaveApplicationData()
+            }
+        }
+
+    private fun selfApiClient(teamId: UUID? = APPLICATION_TEAM_ID.value): SelfApiClient =
+        mockk {
+            coEvery { getSelfUser() } returns SelfUserResponse(
+                qualifiedId = APPLICATION_QUALIFIED_ID,
+                teamId = teamId
+            )
+        }
+
+    private companion object {
+        val APPLICATION_QUALIFIED_ID = QualifiedId(
+            id = UUID.randomUUID(),
+            domain = "wire.example.com"
+        )
+        val APPLICATION_TEAM_ID = TeamId(UUID.randomUUID())
+    }
+}

--- a/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
+++ b/lib/src/test/kotlin/com/wire/sdk/utils/MockCoreCryptoClient.kt
@@ -177,10 +177,6 @@ internal class MockCoreCryptoClient private constructor(
                 databaseKey = DatabaseKey(IsolatedKoinContext.getCryptographyStorageKey())
             )
 
-            // The real cryptoClient creation also sets this property. Keep the same
-            //  approach for consistency. This will change anyway when demo users are removed
-            IsolatedKoinContext.setBackendDomain("staging.zinfra.io")
-
             return MockCoreCryptoClient(
                 ciphersuite = ciphersuite,
                 coreCryptoClient = coreCryptoClient

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/Main.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/Main.java
@@ -22,13 +22,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.UUID;
 
 public class Main {
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
-    final static UUID MY_APPLICATION_ID = UUID.fromString(System.getenv("WIRE_SDK_APPLICATION_ID"));
     final static String WIRE_API_TOKEN = System.getenv("WIRE_SDK_API_TOKEN");
     final static String WIRE_API_HOST = System.getenv("WIRE_SDK_API_HOST");
 
@@ -50,7 +48,6 @@ public class Main {
         Arrays.fill(secureKey, (byte) 1);
 
         return new WireAppSdk(
-            MY_APPLICATION_ID,
             WIRE_API_TOKEN,
             WIRE_API_HOST,
             secureKey,

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/standalone/CreateGroupConversationExample.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/standalone/CreateGroupConversationExample.java
@@ -21,14 +21,12 @@ import com.wire.sdk.model.QualifiedId;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * This example collects all user IDs from the conversations that the app is involved.
  * And then creates a new group conversation with those users as members.
  */
 public class CreateGroupConversationExample {
-    final static UUID MY_APPLICATION_ID = UUID.fromString(System.getenv("WIRE_SDK_APPLICATION_ID"));
     final static String WIRE_API_TOKEN = System.getenv("WIRE_SDK_API_TOKEN");
     final static String WIRE_API_HOST = System.getenv("WIRE_SDK_API_HOST");
 
@@ -41,7 +39,7 @@ public class CreateGroupConversationExample {
     private void initApp() {
         byte[] secureKey = new byte[32];
         Arrays.fill(secureKey, (byte) 1);
-        app = new WireAppSdk(MY_APPLICATION_ID, WIRE_API_TOKEN, WIRE_API_HOST,
+        app = new WireAppSdk(WIRE_API_TOKEN, WIRE_API_HOST,
                 secureKey,
                 new NoOpWireEventsHandler()); // We use a no-op event handler since we don't need to react to any events in this example
         app.startListening();

--- a/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/standalone/SendMessageToAllConversationsExample.java
+++ b/sample/sample-java/src/main/java/com/wire/sdk/sample/examples/standalone/SendMessageToAllConversationsExample.java
@@ -28,7 +28,6 @@ import java.util.UUID;
  * every 5 seconds, for a total of 10 times.
  */
 public class SendMessageToAllConversationsExample {
-    final static UUID MY_APPLICATION_ID = UUID.fromString(System.getenv("WIRE_SDK_APPLICATION_ID"));
     final static String WIRE_API_TOKEN = System.getenv("WIRE_SDK_API_TOKEN");
     final static String WIRE_API_HOST = System.getenv("WIRE_SDK_API_HOST");
 
@@ -41,7 +40,7 @@ public class SendMessageToAllConversationsExample {
     private void initApp() {
         byte[] secureKey = new byte[32];
         Arrays.fill(secureKey, (byte) 1);
-        app = new WireAppSdk(MY_APPLICATION_ID, WIRE_API_TOKEN, WIRE_API_HOST,
+        app = new WireAppSdk(WIRE_API_TOKEN, WIRE_API_HOST,
                 secureKey,
                 new NoOpWireEventsHandler()); // We use a no-op event handler since we don't need to react to any events in this example
         app.startListening();

--- a/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/Main.kt
+++ b/sample/sample-kotlin/src/main/kotlin/com/wire/sdk/sample/Main.kt
@@ -41,7 +41,6 @@ fun main() {
     val secureKey = ByteArray(32) { 1 }
 
     val wireAppSdk = WireAppSdk(
-        applicationId = UUID.fromString(System.getenv("WIRE_SDK_APPLICATION_ID")),
         apiToken = System.getenv("WIRE_SDK_API_TOKEN"),
         apiHost = System.getenv("WIRE_SDK_API_HOST"),
         cryptographyStorageKey = secureKey,
@@ -60,13 +59,12 @@ fun main() {
     applicationManager.getConversations().forEach {
         logger.info("Conversation: $it")
     }
-    val backendConfig = applicationManager.getBackendConfiguration()
-    val selfUser = QualifiedId(
-        id = UUID.fromString(System.getenv("WIRE_SDK_APPLICATION_ID")),
-        domain = backendConfig.domain
-    )
-    logger.info(applicationManager.getUser(selfUser).toString())
-    logger.info("Wire backend domain: ${backendConfig.domain}")
+
+
+    val applicationQualifiedId = applicationManager.getApplicationQualifiedId()
+
+    logger.info(applicationManager.getUser(applicationQualifiedId).toString())
+    logger.info("Wire backend domain: ${applicationQualifiedId.domain}")
 
     // Use wireAppSdk.stopListening() to stop the SDK or just stop it with Ctrl+C/Cmd+C
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues



### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

Now to initialize the SDK, you only need to pass the `apiToken`, `apiHost`, `cryptographyStorageKey` and `wireEventsHandler`.

`applicationId` and `applicationDomain` are now fetched once the SDK starts.

- Fetch App qualifiedId from `GET /self` during SDK initialization (in first calls of client registration) and persist it in `AppStorage`
- Removed userId/userDomain from SDK initialization and related DI tokens Updated App identity usage in crypto, conversation and leave-conversation
- Added/updated tests for SelfApiClient, SelfService and other identity services
- Store application `teamId` from `GET /self`
- Validate stored app qualified id and team id still matches app token
- Expose `getApplicationQualifiedId()`
- Expose `getApplicationTeamId()`


### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

##### Test 1
- Remove`WIRE_SDK_APPLICATION_ID`  from your `.env`
- Run the Sample App
- Everything should be running and working as before

##### Test 2
- From the sample App you can now use `manager.getAplicationQualifiedId()` and `manager.getApplicationTeamId()`